### PR TITLE
Release Chains: update FeatureService and FeatureRepository using @query

### DIFF
--- a/src/main/java/com/sivalabs/ft/features/api/controllers/ReleaseController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/ReleaseController.java
@@ -20,15 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
@@ -99,7 +91,8 @@ class ReleaseController {
             })
     ResponseEntity<Void> createRelease(@RequestBody @Valid CreateReleasePayload payload) {
         var username = SecurityUtils.getCurrentUsername();
-        var cmd = new CreateReleaseCommand(payload.productCode(), payload.code(), payload.description(), username);
+        var cmd = new CreateReleaseCommand(
+                payload.productCode(), payload.code(), payload.description(), payload.parentCode(), username);
         String code = releaseService.createRelease(cmd);
         log.info("Created release with code {}", code);
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
@@ -121,8 +114,8 @@ class ReleaseController {
             })
     void updateRelease(@PathVariable String code, @RequestBody UpdateReleasePayload payload) {
         var username = SecurityUtils.getCurrentUsername();
-        var cmd =
-                new UpdateReleaseCommand(code, payload.description(), payload.status(), payload.releasedAt(), username);
+        var cmd = new UpdateReleaseCommand(
+                code, payload.description(), payload.status(), payload.releasedAt(), payload.parentCode(), username);
         releaseService.updateRelease(cmd);
     }
 

--- a/src/main/java/com/sivalabs/ft/features/api/models/CreateReleasePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/CreateReleasePayload.java
@@ -6,4 +6,5 @@ import jakarta.validation.constraints.Size;
 public record CreateReleasePayload(
         @NotEmpty(message = "Product code is required") String productCode,
         @Size(max = 50, message = "Release code cannot exceed 50 characters") @NotEmpty(message = "Release code is required") String code,
-        String description) {}
+        String description,
+        String parentCode) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/UpdateReleasePayload.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/UpdateReleasePayload.java
@@ -3,4 +3,4 @@ package com.sivalabs.ft.features.api.models;
 import com.sivalabs.ft.features.domain.models.ReleaseStatus;
 import java.time.Instant;
 
-public record UpdateReleasePayload(String description, ReleaseStatus status, Instant releasedAt) {}
+public record UpdateReleasePayload(String description, ReleaseStatus status, Instant releasedAt, String parentCode) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/Commands.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/Commands.java
@@ -15,10 +15,16 @@ public class Commands {
             String code, String prefix, String name, String description, String imageUrl, String updatedBy) {}
 
     /* Release Commands */
-    public record CreateReleaseCommand(String productCode, String code, String description, String createdBy) {}
+    public record CreateReleaseCommand(
+            String productCode, String code, String description, String parentCode, String createdBy) {}
 
     public record UpdateReleaseCommand(
-            String code, String description, ReleaseStatus status, Instant releasedAt, String updatedBy) {}
+            String code,
+            String description,
+            ReleaseStatus status,
+            Instant releasedAt,
+            String parentCode,
+            String updatedBy) {}
 
     /* Feature Commands */
     public record CreateFeatureCommand(

--- a/src/main/java/com/sivalabs/ft/features/domain/FeatureRepository.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/FeatureRepository.java
@@ -14,6 +14,25 @@ interface FeatureRepository extends ListCrudRepository<Feature, Long> {
     @Query("select f from Feature f left join fetch f.release where f.release.code = :releaseCode")
     List<Feature> findByReleaseCode(String releaseCode);
 
+    @Query(
+            value =
+                    """
+            WITH RECURSIVE release_hierarchy AS (
+                SELECT r.id, r.code, r.parent_id
+                FROM releases r
+                WHERE r.code = :releaseCode
+                UNION ALL
+                SELECT r.id, r.code, r.parent_id
+                FROM releases r
+                JOIN release_hierarchy rh ON r.id = rh.parent_id
+            )
+            SELECT f.* FROM features f
+            JOIN releases r ON f.release_id = r.id
+            WHERE r.code IN (SELECT rh.code FROM release_hierarchy rh)
+            """,
+            nativeQuery = true)
+    List<Feature> findByReleaseCodeWithParents(String releaseCode);
+
     @Query("select f from Feature f left join fetch f.release where f.product.code = :productCode")
     List<Feature> findByProductCode(String productCode);
 

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/ReleaseDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/ReleaseDto.java
@@ -10,6 +10,7 @@ public record ReleaseDto(
         String description,
         ReleaseStatus status,
         Instant releasedAt,
+        String parentCode,
         String createdBy,
         Instant createdAt,
         String updatedBy,

--- a/src/main/java/com/sivalabs/ft/features/domain/entities/Release.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/entities/Release.java
@@ -60,6 +60,13 @@ public class Release {
     @Column(name = "updated_at")
     private Instant updatedAt;
 
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private Release parent;
+
+    @OneToMany(mappedBy = "parent")
+    private Set<Release> children = new LinkedHashSet<>();
+
     @OneToMany(mappedBy = "release")
     private Set<Feature> features = new LinkedHashSet<>();
 
@@ -149,5 +156,21 @@ public class Release {
 
     public void setFeatures(Set<Feature> features) {
         this.features = features;
+    }
+
+    public Release getParent() {
+        return parent;
+    }
+
+    public void setParent(Release parent) {
+        this.parent = parent;
+    }
+
+    public Set<Release> getChildren() {
+        return children;
+    }
+
+    public void setChildren(Set<Release> children) {
+        this.children = children;
     }
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/ReleaseMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/ReleaseMapper.java
@@ -3,8 +3,16 @@ package com.sivalabs.ft.features.domain.mappers;
 import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
 import com.sivalabs.ft.features.domain.entities.Release;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring")
 public interface ReleaseMapper {
+    @Mapping(target = "parentCode", source = "parent", qualifiedByName = "mapParentCode")
     ReleaseDto toDto(Release release);
+
+    @Named("mapParentCode")
+    default String mapParentCode(Release parent) {
+        return parent != null ? parent.getCode() : null;
+    }
 }

--- a/src/main/resources/db/migration/V1__create_feature_tables.sql
+++ b/src/main/resources/db/migration/V1__create_feature_tables.sql
@@ -22,6 +22,7 @@ create table releases
 (
     id          bigint       not null default nextval('release_id_seq'),
     product_id  bigint       not null,
+    parent_id   bigint,
     code        varchar(50)  not null unique,
     description text,
     status      varchar(50)  not null,

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -12,19 +12,24 @@ insert into products (id, code, prefix, name, description, image_url, disabled, 
 (5, 'rider','RIDER','Rider', 'JetBrains IDE for .NET', 'https://resources.jetbrains.com/storage/products/company/brand/logos/Rider.png',false, 'admin','2024-03-01 00:00:00')
 ;
 
-insert into releases (id, product_id, code, description, status, created_by, created_at) values
-(1, 1, 'IDEA-2023.3.8', 'IntelliJ IDEA 2023.3.8', 'RELEASED', 'admin','2023-03-25'),
-(2, 1, 'IDEA-2024.2.3', 'IntelliJ IDEA 2024.2.4', 'RELEASED', 'admin','2024-02-25'),
-(3, 2, 'GO-2024.2.3', 'GoLand 2024.2.4', 'RELEASED', 'admin','2024-02-15'),
-(4, 3, 'WEB-2024.2.3', 'WebStorm 2024.2.4', 'RELEASED', 'admin','2024-02-20'),
-(5, 4, 'PY-2024.2.3', 'PyCharm 2024.2.4', 'RELEASED', 'admin','2024-02-20'),
-(6, 5, 'RIDER-2024.2.6', 'Rider 2024.2.6', 'RELEASED', 'admin','2024-02-16')
+insert into releases (id, product_id, code, description, status, created_by, created_at, parent_id) values
+(1, 1, 'IDEA-2023.3.8', 'IntelliJ IDEA 2023.3.8', 'RELEASED', 'admin','2023-03-25', null),
+(2, 1, 'IDEA-2024.2.3', 'IntelliJ IDEA 2024.2.4', 'RELEASED', 'admin','2024-02-25', 1),
+(3, 2, 'GO-2024.2.3', 'GoLand 2024.2.4', 'RELEASED', 'admin','2024-02-15', null),
+(4, 3, 'WEB-2024.2.3', 'WebStorm 2024.2.4', 'RELEASED', 'admin','2024-02-20', null),
+(5, 4, 'PY-2024.2.3', 'PyCharm 2024.2.4', 'RELEASED', 'admin','2024-02-20', null),
+(6, 5, 'RIDER-2024.2.6', 'Rider 2024.2.6', 'RELEASED', 'admin','2024-02-16', null),
+(7, 1, 'IDEA-2024.2.4', 'IntelliJ IDEA 2024.2.4 Patch', 'RELEASED', 'admin','2024-03-10', 2)
 ;
 
 insert into features (id, product_id, release_id, code, title, description, status, created_by, assigned_to, created_at) values
 (1, 1, 1, 'IDEA-1', 'Redesign Structure Tool Window', 'Redesign Structure Tool Window to show logical structure', 'NEW', 'siva', 'marcobehler', '2024-02-24'),
 (2, 1, 1, 'IDEA-2', 'SDJ Repository Method AutoCompletion', 'Spring Data JPA Repository Method AutoCompletion as you type', 'NEW', 'daniiltsarev', 'siva', '2024-03-14'),
-(3, 2, null, 'GO-3', 'Make Go to Type and Go to Symbol dumb aware', 'Make Go to Type and Go to Symbol dumb aware', 'IN_PROGRESS', 'antonarhipov', 'andreybelyaev', '2024-01-14')
+(3, 2, null, 'GO-3', 'Make Go to Type and Go to Symbol dumb aware', 'Make Go to Type and Go to Symbol dumb aware', 'IN_PROGRESS', 'antonarhipov', 'andreybelyaev', '2024-01-14'),
+(4, 1, 2, 'IDEA-3', 'Improve Code Completion', 'Improve code completion for Java', 'NEW', 'siva', 'marcobehler', '2024-02-26'),
+(5, 1, 2, 'IDEA-4', 'Better Maven Support', 'Improve Maven integration', 'IN_PROGRESS', 'daniiltsarev', 'siva', '2024-02-27'),
+(6, 1, 7, 'IDEA-5', 'Fix Memory Leak', 'Fix memory leak in editor', 'NEW', 'siva', 'marcobehler', '2024-03-11'),
+(7, 1, 7, 'IDEA-6', 'Improve Startup Time', 'Make startup faster', 'IN_PROGRESS', 'daniiltsarev', 'siva', '2024-03-12')
 ;
 
 insert into favorite_features (id, feature_id, user_id) values


### PR DESCRIPTION
Ref https://github.com/jetbrains-eval-lab/feature-service/issues/27
Update findFeaturesByReleaseAndParents in FeatureService. If fromParentReleaseCode is empty, call a new method findByReleaseCodeWithParents from featureRepository. Implement findByReleaseCodeWithParents using @query for direct DB access (SQL or JPQL)

FAIL_TO_PASS: FeatureControllerTests