### PR TITLE
Release Planning and Roadmapping : Roadmap Visualization & Core Export

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,22 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
+        <!-- PDF Generation - iText 8.x -->
+        <dependency>
+            <groupId>com.itextpdf</groupId>
+            <artifactId>kernel</artifactId>
+            <version>8.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.itextpdf</groupId>
+            <artifactId>layout</artifactId>
+            <version>8.0.5</version>
+        </dependency>
+        <!-- CSV Generation -->
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>5.7.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/sivalabs/ft/features/api/GlobalExceptionHandler.java
@@ -8,8 +8,10 @@ import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -39,6 +41,25 @@ class GlobalExceptionHandler {
         log.error("Bad Request", e);
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, e.getMessage());
         problemDetail.setTitle("Bad Request");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    ProblemDetail handle(MissingServletRequestParameterException e) {
+        log.error("Missing required request parameter", e);
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, e.getMessage());
+        problemDetail.setTitle("Missing Required Parameter");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    ProblemDetail handle(MethodArgumentTypeMismatchException e) {
+        log.error("Method argument type mismatch", e);
+        String message = String.format("Invalid value '%s' for parameter '%s'", e.getValue(), e.getName());
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(BAD_REQUEST, message);
+        problemDetail.setTitle("Invalid Parameter Value");
         problemDetail.setProperty("timestamp", Instant.now());
         return problemDetail;
     }

--- a/src/main/java/com/sivalabs/ft/features/api/controllers/RoadmapController.java
+++ b/src/main/java/com/sivalabs/ft/features/api/controllers/RoadmapController.java
@@ -1,0 +1,159 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import com.sivalabs.ft.features.api.models.RoadmapResponse;
+import com.sivalabs.ft.features.domain.ReportingService;
+import com.sivalabs.ft.features.domain.RoadmapService;
+import com.sivalabs.ft.features.domain.exceptions.BadRequestException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
+import java.time.LocalDate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/roadmap")
+@Tag(name = "Roadmap API", description = "APIs for product roadmap visualization and export")
+public class RoadmapController {
+
+    private static final Logger log = LoggerFactory.getLogger(RoadmapController.class);
+
+    private final RoadmapService roadmapService;
+    private final ReportingService reportingService;
+
+    public RoadmapController(RoadmapService roadmapService, ReportingService reportingService) {
+        this.roadmapService = roadmapService;
+        this.reportingService = reportingService;
+    }
+
+    @GetMapping("")
+    @Operation(
+            summary = "Get product roadmap",
+            description = "Retrieve product roadmap with releases, features, progress metrics and health indicators",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful response",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = RoadmapResponse.class))),
+                @ApiResponse(responseCode = "400", description = "Invalid request parameters")
+            })
+    public ResponseEntity<RoadmapResponse> getRoadmap(
+            @Parameter(description = "List of product codes to filter by")
+                    @RequestParam(value = "productCodes", required = false)
+                    String[] productCodes,
+            @Parameter(description = "List of release statuses to filter by")
+                    @RequestParam(value = "statuses", required = false)
+                    String[] statuses,
+            @Parameter(description = "Filter releases from this date (inclusive)")
+                    @RequestParam(value = "dateFrom", required = false)
+                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate dateFrom,
+            @Parameter(description = "Filter releases to this date (inclusive)")
+                    @RequestParam(value = "dateTo", required = false)
+                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate dateTo,
+            @Parameter(description = "Group releases by field (productCode, status, owner)")
+                    @RequestParam(value = "groupBy", required = false)
+                    String groupBy,
+            @Parameter(description = "Filter releases by owner") @RequestParam(value = "owner", required = false)
+                    String owner) {
+        try {
+            log.info(
+                    "Fetching roadmap with filters - productCodes: {}, statuses: {}, dateFrom: {}, dateTo: {}, groupBy: {}, owner: {}",
+                    productCodes,
+                    statuses,
+                    dateFrom,
+                    dateTo,
+                    groupBy,
+                    owner);
+
+            RoadmapResponse roadmap =
+                    roadmapService.getRoadmap(productCodes, statuses, dateFrom, dateTo, groupBy, owner);
+
+            log.info(
+                    "Successfully retrieved roadmap with {} items",
+                    roadmap.roadmapItems().size());
+            return ResponseEntity.ok(roadmap);
+
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid request parameters: {}", e.getMessage());
+            throw new BadRequestException(e.getMessage());
+        } catch (Exception e) {
+            log.error("Error retrieving roadmap", e);
+            throw new RuntimeException("Internal server error while retrieving roadmap", e);
+        }
+    }
+
+    @GetMapping("/export")
+    @Operation(
+            summary = "Export roadmap",
+            description = "Export roadmap data in CSV or PDF format with the same filtering options",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Successful export",
+                        content = {@Content(mediaType = "text/csv"), @Content(mediaType = "application/pdf")}),
+                @ApiResponse(responseCode = "400", description = "Invalid request parameters or format")
+            })
+    public ResponseEntity<ByteArrayResource> exportRoadmap(
+            @Parameter(description = "Export format (CSV or PDF)", required = true) @RequestParam(value = "format")
+                    String format,
+            @Parameter(description = "List of product codes to filter by")
+                    @RequestParam(value = "productCodes", required = false)
+                    String[] productCodes,
+            @Parameter(description = "List of release statuses to filter by")
+                    @RequestParam(value = "statuses", required = false)
+                    String[] statuses,
+            @Parameter(description = "Filter releases from this date (inclusive)")
+                    @RequestParam(value = "dateFrom", required = false)
+                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate dateFrom,
+            @Parameter(description = "Filter releases to this date (inclusive)")
+                    @RequestParam(value = "dateTo", required = false)
+                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate dateTo,
+            @Parameter(description = "Group releases by field (productCode, status, owner)")
+                    @RequestParam(value = "groupBy", required = false)
+                    String groupBy,
+            @Parameter(description = "Filter releases by owner") @RequestParam(value = "owner", required = false)
+                    String owner) {
+        try {
+            log.info(
+                    "Exporting roadmap in {} format with filters - productCodes: {}, statuses: {}, dateFrom: {}, dateTo: {}, groupBy: {}, owner: {}",
+                    format,
+                    productCodes,
+                    statuses,
+                    dateFrom,
+                    dateTo,
+                    groupBy,
+                    owner);
+
+            ResponseEntity<ByteArrayResource> exportResponse =
+                    reportingService.exportRoadmap(format, productCodes, statuses, dateFrom, dateTo, groupBy, owner);
+
+            log.info("Successfully exported roadmap in {} format", format);
+            return exportResponse;
+
+        } catch (IllegalArgumentException e) {
+            log.warn("Invalid export request parameters: {}", e.getMessage());
+            throw new BadRequestException(e.getMessage());
+        } catch (IOException e) {
+            log.error("Error generating export file", e);
+            throw new RuntimeException("Internal server error while generating export file", e);
+        } catch (Exception e) {
+            log.error("Error exporting roadmap", e);
+            throw new RuntimeException("Internal server error while exporting roadmap", e);
+        }
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/api/models/AppliedFilters.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/AppliedFilters.java
@@ -1,0 +1,6 @@
+package com.sivalabs.ft.features.api.models;
+
+import java.time.LocalDate;
+
+public record AppliedFilters(
+        String[] productCodes, String[] statuses, LocalDate dateFrom, LocalDate dateTo, String groupBy, String owner) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/HealthIndicators.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/HealthIndicators.java
@@ -1,0 +1,3 @@
+package com.sivalabs.ft.features.api.models;
+
+public record HealthIndicators(String riskLevel, String timelineAdherence) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/ProductInfo.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/ProductInfo.java
@@ -1,0 +1,3 @@
+package com.sivalabs.ft.features.api.models;
+
+public record ProductInfo(String code, String name) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/ProgressMetrics.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/ProgressMetrics.java
@@ -1,0 +1,9 @@
+package com.sivalabs.ft.features.api.models;
+
+public record ProgressMetrics(
+        Integer totalFeatures,
+        Integer completedFeatures,
+        Integer inProgressFeatures,
+        Integer newFeatures,
+        Integer onHoldFeatures,
+        Double completionPercentage) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/RoadmapFeature.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/RoadmapFeature.java
@@ -1,0 +1,16 @@
+package com.sivalabs.ft.features.api.models;
+
+import java.time.Instant;
+
+public record RoadmapFeature(
+        Long id,
+        String code,
+        String title,
+        String description,
+        String status,
+        String releaseCode,
+        String assignedTo,
+        String createdBy,
+        Instant createdAt,
+        String updatedBy,
+        Instant updatedAt) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/RoadmapItem.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/RoadmapItem.java
@@ -1,0 +1,9 @@
+package com.sivalabs.ft.features.api.models;
+
+import java.util.List;
+
+public record RoadmapItem(
+        RoadmapRelease release,
+        ProgressMetrics progressMetrics,
+        HealthIndicators healthIndicators,
+        List<RoadmapFeature> features) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/RoadmapRelease.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/RoadmapRelease.java
@@ -1,15 +1,13 @@
-package com.sivalabs.ft.features.domain.dtos;
+package com.sivalabs.ft.features.api.models;
 
-import com.sivalabs.ft.features.domain.models.ReleaseStatus;
-import java.io.Serializable;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.Instant;
 
-public record ReleaseDto(
+public record RoadmapRelease(
         Long id,
-        ProductDto product,
         String code,
         String description,
-        ReleaseStatus status,
+        String status,
         Instant releasedAt,
         Instant plannedStartDate,
         Instant plannedReleaseDate,
@@ -19,5 +17,5 @@ public record ReleaseDto(
         String createdBy,
         Instant createdAt,
         String updatedBy,
-        Instant updatedAt)
-        implements Serializable {}
+        Instant updatedAt,
+        @JsonIgnore ProductInfo product) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/RoadmapResponse.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/RoadmapResponse.java
@@ -1,0 +1,5 @@
+package com.sivalabs.ft.features.api.models;
+
+import java.util.List;
+
+public record RoadmapResponse(List<RoadmapItem> roadmapItems, RoadmapSummary summary, AppliedFilters appliedFilters) {}

--- a/src/main/java/com/sivalabs/ft/features/api/models/RoadmapSummary.java
+++ b/src/main/java/com/sivalabs/ft/features/api/models/RoadmapSummary.java
@@ -1,0 +1,8 @@
+package com.sivalabs.ft.features.api.models;
+
+public record RoadmapSummary(
+        Integer totalReleases,
+        Integer completedReleases,
+        Integer draftReleases,
+        Integer totalFeatures,
+        Double overallCompletionPercentage) {}

--- a/src/main/java/com/sivalabs/ft/features/domain/ReportingService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/ReportingService.java
@@ -1,0 +1,251 @@
+package com.sivalabs.ft.features.domain;
+
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfWriter;
+import com.itextpdf.layout.Document;
+import com.itextpdf.layout.element.Cell;
+import com.itextpdf.layout.element.Paragraph;
+import com.itextpdf.layout.element.Table;
+import com.itextpdf.layout.properties.TextAlignment;
+import com.itextpdf.layout.properties.UnitValue;
+import com.opencsv.CSVWriter;
+import com.sivalabs.ft.features.api.models.RoadmapItem;
+import com.sivalabs.ft.features.api.models.RoadmapResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReportingService {
+
+    private final RoadmapService roadmapService;
+
+    public ReportingService(RoadmapService roadmapService) {
+        this.roadmapService = roadmapService;
+    }
+
+    public ResponseEntity<ByteArrayResource> exportRoadmap(
+            String format,
+            String[] productCodes,
+            String[] statuses,
+            java.time.LocalDate dateFrom,
+            java.time.LocalDate dateTo,
+            String groupBy,
+            String owner)
+            throws IOException {
+
+        if (format == null || format.trim().isEmpty()) {
+            throw new IllegalArgumentException("Format parameter is mandatory");
+        }
+
+        String formatUpper = format.toUpperCase();
+        if (!formatUpper.equals("CSV") && !formatUpper.equals("PDF")) {
+            throw new IllegalArgumentException("Invalid format. Allowed values are CSV and PDF");
+        }
+
+        RoadmapResponse roadmapData =
+                roadmapService.getRoadmap(productCodes, statuses, dateFrom, dateTo, groupBy, owner);
+
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        String fileName = "Roadmap_" + timestamp;
+
+        switch (formatUpper) {
+            case "CSV":
+                return generateCsvExport(roadmapData, fileName);
+            case "PDF":
+                return generatePdfExport(roadmapData, fileName);
+            default:
+                throw new IllegalArgumentException("Unsupported format: " + format);
+        }
+    }
+
+    private ResponseEntity<ByteArrayResource> generateCsvExport(RoadmapResponse roadmapData, String fileName)
+            throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputStream);
+
+        try (CSVWriter csvWriter = new CSVWriter(
+                outputStreamWriter,
+                CSVWriter.DEFAULT_SEPARATOR,
+                CSVWriter.NO_QUOTE_CHARACTER,
+                CSVWriter.DEFAULT_ESCAPE_CHARACTER,
+                CSVWriter.DEFAULT_LINE_END)) {
+            // CSV Headers
+            String[] headers = {
+                "Product Code",
+                "Product Name",
+                "Release Code",
+                "Release Description",
+                "Release Status",
+                "Released At",
+                "Planned Start Date",
+                "Planned Release Date",
+                "Actual Release Date",
+                "Owner",
+                "Total Features",
+                "Completed Features",
+                "In Progress Features",
+                "New Features",
+                "On Hold Features",
+                "Completion Percentage",
+                "Timeline Adherence",
+                "Risk Level"
+            };
+            csvWriter.writeNext(headers);
+
+            // CSV Data
+            for (RoadmapItem item : roadmapData.roadmapItems()) {
+                String productCode = item.release().product() != null
+                        ? item.release().product().code()
+                        : "";
+                String productName = item.release().product() != null
+                        ? item.release().product().name()
+                        : "";
+
+                String[] row = {
+                    productCode,
+                    productName,
+                    item.release().code(),
+                    item.release().description(),
+                    item.release().status(),
+                    formatInstantForCSV(item.release().releasedAt()),
+                    formatInstantForCSV(item.release().plannedStartDate()),
+                    formatInstantForCSV(item.release().plannedReleaseDate()),
+                    formatInstantForCSV(item.release().actualReleaseDate()),
+                    item.release().owner() != null ? item.release().owner() : "",
+                    String.valueOf(item.progressMetrics().totalFeatures()),
+                    String.valueOf(item.progressMetrics().completedFeatures()),
+                    String.valueOf(item.progressMetrics().inProgressFeatures()),
+                    String.valueOf(item.progressMetrics().newFeatures()),
+                    String.valueOf(item.progressMetrics().onHoldFeatures()),
+                    String.valueOf(item.progressMetrics().completionPercentage()),
+                    item.healthIndicators().timelineAdherence() != null
+                            ? item.healthIndicators().timelineAdherence()
+                            : "",
+                    item.healthIndicators().riskLevel() != null
+                            ? item.healthIndicators().riskLevel()
+                            : ""
+                };
+                csvWriter.writeNext(row);
+            }
+
+            csvWriter.flush();
+        }
+
+        byte[] csvBytes = outputStream.toByteArray();
+        ByteArrayResource resource = new ByteArrayResource(csvBytes);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileName + ".csv\"")
+                .contentType(MediaType.parseMediaType("text/csv"))
+                .contentLength(csvBytes.length)
+                .body(resource);
+    }
+
+    private ResponseEntity<ByteArrayResource> generatePdfExport(RoadmapResponse roadmapData, String fileName)
+            throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PdfWriter writer = new PdfWriter(outputStream);
+        PdfDocument pdfDocument = new PdfDocument(writer);
+        Document document = new Document(pdfDocument);
+
+        // Title
+        document.add(new Paragraph("Product Roadmap Report")
+                .setTextAlignment(TextAlignment.CENTER)
+                .setFontSize(18)
+                .setBold());
+
+        document.add(new Paragraph(
+                        "Generated: " + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .setTextAlignment(TextAlignment.CENTER)
+                .setFontSize(12));
+
+        document.add(new Paragraph(" ")); // Spacing
+
+        // Summary section
+        if (roadmapData.summary() != null) {
+            document.add(new Paragraph("Summary").setFontSize(14).setBold());
+
+            document.add(new Paragraph(String.format(
+                    "Total Releases: %d, Completed: %d, Draft: %d, Total Features: %d, Overall Completion: %.2f%%",
+                    roadmapData.summary().totalReleases(),
+                    roadmapData.summary().completedReleases(),
+                    roadmapData.summary().draftReleases(),
+                    roadmapData.summary().totalFeatures(),
+                    roadmapData.summary().overallCompletionPercentage())));
+
+            document.add(new Paragraph(" ")); // Spacing
+        }
+
+        // Main data table
+        if (!roadmapData.roadmapItems().isEmpty()) {
+            document.add(new Paragraph("Roadmap Details").setFontSize(14).setBold());
+
+            Table table = new Table(new float[] {2, 3, 2, 2, 2, 2, 2, 2});
+            table.setWidth(UnitValue.createPercentValue(100));
+
+            // Headers
+            table.addHeaderCell(new Cell().add(new Paragraph("Product").setBold()));
+            table.addHeaderCell(new Cell().add(new Paragraph("Release").setBold()));
+            table.addHeaderCell(new Cell().add(new Paragraph("Status").setBold()));
+            table.addHeaderCell(new Cell().add(new Paragraph("Owner").setBold()));
+            table.addHeaderCell(new Cell().add(new Paragraph("Total Features").setBold()));
+            table.addHeaderCell(new Cell().add(new Paragraph("Completed").setBold()));
+            table.addHeaderCell(new Cell().add(new Paragraph("Completion %").setBold()));
+            table.addHeaderCell(new Cell().add(new Paragraph("Risk Level").setBold()));
+
+            // Data rows
+            for (RoadmapItem item : roadmapData.roadmapItems()) {
+                String productCode = item.release().product() != null
+                        ? item.release().product().code()
+                        : "";
+
+                table.addCell(new Cell().add(new Paragraph(productCode)));
+                table.addCell(new Cell().add(new Paragraph(item.release().code())));
+                table.addCell(new Cell().add(new Paragraph(item.release().status())));
+                table.addCell(new Cell()
+                        .add(new Paragraph(
+                                item.release().owner() != null ? item.release().owner() : "")));
+                table.addCell(new Cell()
+                        .add(new Paragraph(String.valueOf(item.progressMetrics().totalFeatures()))));
+                table.addCell(new Cell()
+                        .add(new Paragraph(String.valueOf(item.progressMetrics().completedFeatures()))));
+                table.addCell(new Cell()
+                        .add(new Paragraph(
+                                String.format("%.2f%%", item.progressMetrics().completionPercentage()))));
+                table.addCell(new Cell()
+                        .add(new Paragraph(
+                                item.healthIndicators().riskLevel() != null
+                                        ? item.healthIndicators().riskLevel()
+                                        : "")));
+            }
+
+            document.add(table);
+        }
+
+        document.close();
+
+        byte[] pdfBytes = outputStream.toByteArray();
+        ByteArrayResource resource = new ByteArrayResource(pdfBytes);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + fileName + ".pdf\"")
+                .contentType(MediaType.APPLICATION_PDF)
+                .contentLength(pdfBytes.length)
+                .body(resource);
+    }
+
+    private String formatInstantForCSV(java.time.Instant instant) {
+        if (instant == null) {
+            return "";
+        }
+        return instant.toString();
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/RoadmapService.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/RoadmapService.java
@@ -1,0 +1,364 @@
+package com.sivalabs.ft.features.domain;
+
+import com.sivalabs.ft.features.api.models.*;
+import com.sivalabs.ft.features.domain.entities.Feature;
+import com.sivalabs.ft.features.domain.entities.Release;
+import com.sivalabs.ft.features.domain.models.FeatureStatus;
+import com.sivalabs.ft.features.domain.models.ReleaseStatus;
+import com.sivalabs.ft.features.domain.models.RiskLevel;
+import com.sivalabs.ft.features.domain.models.TimelineAdherence;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class RoadmapService {
+
+    private final ReleaseRepository releaseRepository;
+    private final FeatureRepository featureRepository;
+
+    public RoadmapService(ReleaseRepository releaseRepository, FeatureRepository featureRepository) {
+        this.releaseRepository = releaseRepository;
+        this.featureRepository = featureRepository;
+    }
+
+    public RoadmapResponse getRoadmap(
+            String[] productCodes,
+            String[] statuses,
+            LocalDate dateFrom,
+            LocalDate dateTo,
+            String groupBy,
+            String owner) {
+
+        // Validate input parameters
+        validateInputParameters(productCodes, statuses, dateFrom, dateTo, groupBy);
+
+        // Get all releases with filters
+        List<Release> releases = getAllReleasesWithFilters(productCodes, statuses, dateFrom, dateTo, owner);
+
+        // Sort releases by priority date (descending)
+        releases.sort(this::compareByPriorityDate);
+
+        // Create roadmap items with metrics and health indicators
+        List<RoadmapItem> roadmapItems =
+                releases.stream().map(this::createRoadmapItem).collect(Collectors.toList());
+
+        // Apply grouping if specified
+        if (groupBy != null && !groupBy.isEmpty()) {
+            roadmapItems = applyGrouping(roadmapItems, groupBy.toLowerCase());
+        }
+
+        // Calculate summary
+        RoadmapSummary summary = calculateSummary(roadmapItems);
+
+        // Create applied filters
+        AppliedFilters appliedFilters = new AppliedFilters(productCodes, statuses, dateFrom, dateTo, groupBy, owner);
+
+        return new RoadmapResponse(roadmapItems, summary, appliedFilters);
+    }
+
+    private void validateInputParameters(
+            String[] productCodes, String[] statuses, LocalDate dateFrom, LocalDate dateTo, String groupBy) {
+
+        // Validate statuses against enum values
+        if (statuses != null) {
+            Set<String> validStatuses = Arrays.stream(ReleaseStatus.values())
+                    .map(Enum::name)
+                    .map(String::toUpperCase)
+                    .collect(Collectors.toSet());
+
+            for (String status : statuses) {
+                if (!validStatuses.contains(status.toUpperCase())) {
+                    throw new IllegalArgumentException("Invalid status: " + status);
+                }
+            }
+        }
+
+        // Validate date range
+        if (dateFrom != null && dateTo != null && dateFrom.isAfter(dateTo)) {
+            throw new IllegalArgumentException("dateFrom cannot be after dateTo");
+        }
+
+        // Validate groupBy values
+        if (groupBy != null && !groupBy.isEmpty()) {
+            Set<String> validGroupBy = Set.of("productcode", "status", "owner");
+            if (!validGroupBy.contains(groupBy.toLowerCase())) {
+                throw new IllegalArgumentException("Invalid groupBy value: " + groupBy);
+            }
+        }
+    }
+
+    private List<Release> getAllReleasesWithFilters(
+            String[] productCodes, String[] statuses, LocalDate dateFrom, LocalDate dateTo, String owner) {
+        List<Release> allReleases = releaseRepository.findAll();
+
+        return allReleases.stream()
+                .filter(release -> filterByProductCodes(release, productCodes))
+                .filter(release -> filterByStatuses(release, statuses))
+                .filter(release -> filterByDateRange(release, dateFrom, dateTo))
+                .filter(release -> filterByOwner(release, owner))
+                .collect(Collectors.toList());
+    }
+
+    private boolean filterByProductCodes(Release release, String[] productCodes) {
+        if (productCodes == null || productCodes.length == 0) {
+            return true;
+        }
+        return Arrays.asList(productCodes).contains(release.getProduct().getCode());
+    }
+
+    private boolean filterByStatuses(Release release, String[] statuses) {
+        if (statuses == null || statuses.length == 0) {
+            return true;
+        }
+        return Arrays.stream(statuses)
+                .anyMatch(status -> status.equalsIgnoreCase(release.getStatus().name()));
+    }
+
+    private boolean filterByDateRange(Release release, LocalDate dateFrom, LocalDate dateTo) {
+        Instant priorityDate = getPriorityDateForSorting(release);
+        if (priorityDate == null) {
+            return true; // Include releases without dates when filtering by date
+        }
+
+        LocalDate releaseDate = priorityDate.atZone(ZoneId.systemDefault()).toLocalDate();
+
+        boolean afterFrom = dateFrom == null || !releaseDate.isBefore(dateFrom);
+        boolean beforeTo = dateTo == null || !releaseDate.isAfter(dateTo);
+
+        return afterFrom && beforeTo;
+    }
+
+    private boolean filterByOwner(Release release, String owner) {
+        if (owner == null || owner.isEmpty()) {
+            return true;
+        }
+        return Objects.equals(release.getOwner(), owner);
+    }
+
+    private int compareByPriorityDate(Release r1, Release r2) {
+        Instant date1 = getPriorityDateForSorting(r1);
+        Instant date2 = getPriorityDateForSorting(r2);
+
+        // Nulls last, then descending order
+        if (date1 == null && date2 == null) return 0;
+        if (date1 == null) return 1;
+        if (date2 == null) return -1;
+
+        return date2.compareTo(date1); // Descending order
+    }
+
+    private Instant getPriorityDateForSorting(Release release) {
+        if (release.getActualReleaseDate() != null) {
+            return release.getActualReleaseDate();
+        }
+        if (release.getReleasedAt() != null) {
+            return release.getReleasedAt();
+        }
+        if (release.getPlannedReleaseDate() != null) {
+            return release.getPlannedReleaseDate();
+        }
+        return release.getCreatedAt();
+    }
+
+    private RoadmapItem createRoadmapItem(Release release) {
+        // Create product info
+        ProductInfo productInfo = new ProductInfo(
+                release.getProduct().getCode(), release.getProduct().getName());
+
+        // Create RoadmapRelease directly from Release entity
+        RoadmapRelease roadmapRelease = new RoadmapRelease(
+                release.getId(),
+                release.getCode(),
+                release.getDescription(),
+                release.getStatus().name(),
+                release.getReleasedAt(),
+                release.getPlannedStartDate(),
+                release.getPlannedReleaseDate(),
+                release.getActualReleaseDate(),
+                release.getOwner(),
+                release.getNotes(),
+                release.getCreatedBy(),
+                release.getCreatedAt(),
+                release.getUpdatedBy(),
+                release.getUpdatedAt(),
+                productInfo);
+
+        // Get features for this release
+        List<Feature> features = featureRepository.findByReleaseCode(release.getCode());
+        List<RoadmapFeature> roadmapFeatures =
+                features.stream().map(this::convertToRoadmapFeature).collect(Collectors.toList());
+
+        // Calculate progress metrics
+        ProgressMetrics progressMetrics = calculateProgressMetrics(features);
+
+        // Calculate health indicators
+        HealthIndicators healthIndicators = calculateHealthIndicators(release, features);
+
+        return new RoadmapItem(roadmapRelease, progressMetrics, healthIndicators, roadmapFeatures);
+    }
+
+    private RoadmapFeature convertToRoadmapFeature(Feature feature) {
+        return new RoadmapFeature(
+                feature.getId(),
+                feature.getCode(),
+                feature.getTitle(),
+                feature.getDescription(),
+                feature.getStatus().name(),
+                feature.getRelease() != null ? feature.getRelease().getCode() : null,
+                feature.getAssignedTo(),
+                feature.getCreatedBy(),
+                feature.getCreatedAt(),
+                feature.getUpdatedBy(),
+                feature.getUpdatedAt());
+    }
+
+    private ProgressMetrics calculateProgressMetrics(List<Feature> features) {
+        int totalFeatures = features.size();
+        if (totalFeatures == 0) {
+            return new ProgressMetrics(0, 0, 0, 0, 0, 0.0);
+        }
+
+        Map<FeatureStatus, Long> statusCounts =
+                features.stream().collect(Collectors.groupingBy(Feature::getStatus, Collectors.counting()));
+
+        int completedFeatures =
+                statusCounts.getOrDefault(FeatureStatus.RELEASED, 0L).intValue();
+        int inProgressFeatures =
+                statusCounts.getOrDefault(FeatureStatus.IN_PROGRESS, 0L).intValue();
+        int newFeatures = statusCounts.getOrDefault(FeatureStatus.NEW, 0L).intValue();
+        int onHoldFeatures =
+                statusCounts.getOrDefault(FeatureStatus.ON_HOLD, 0L).intValue();
+
+        double completionPercentage = totalFeatures > 0 ? (double) completedFeatures / totalFeatures * 100.0 : 0.0;
+
+        return new ProgressMetrics(
+                totalFeatures,
+                completedFeatures,
+                inProgressFeatures,
+                newFeatures,
+                onHoldFeatures,
+                Math.round(completionPercentage * 100.0) / 100.0 // Round to 2 decimal places
+                );
+    }
+
+    private HealthIndicators calculateHealthIndicators(Release release, List<Feature> features) {
+        RiskLevel riskLevel = calculateRiskLevel(features);
+        TimelineAdherence timelineAdherence = calculateTimelineAdherence(release);
+
+        return new HealthIndicators(
+                riskLevel != null ? riskLevel.name() : null,
+                timelineAdherence != null ? timelineAdherence.name() : null);
+    }
+
+    private RiskLevel calculateRiskLevel(List<Feature> features) {
+        if (features.isEmpty()) {
+            return RiskLevel.ZERO;
+        }
+
+        long onHoldCount = features.stream()
+                .mapToLong(f -> f.getStatus() == FeatureStatus.ON_HOLD ? 1 : 0)
+                .sum();
+
+        double onHoldPercentage = (double) onHoldCount / features.size() * 100.0;
+
+        if (onHoldCount == 0) {
+            return RiskLevel.ZERO;
+        } else if (onHoldPercentage < 10.0) {
+            return RiskLevel.LOW;
+        } else if (onHoldPercentage > 10.0 && onHoldPercentage <= 30.0) {
+            return RiskLevel.MEDIUM;
+        } else {
+            return RiskLevel.HIGH;
+        }
+    }
+
+    private TimelineAdherence calculateTimelineAdherence(Release release) {
+        Instant plannedReleaseDate = release.getPlannedReleaseDate();
+        if (plannedReleaseDate == null) {
+            return null;
+        }
+
+        Instant actualDate = release.getActualReleaseDate();
+        if (actualDate == null) {
+            actualDate = release.getReleasedAt();
+        }
+
+        // For finished releases, compare actual vs planned
+        if (actualDate != null) {
+            long daysDifference =
+                    (actualDate.toEpochMilli() - plannedReleaseDate.toEpochMilli()) / (24 * 60 * 60 * 1000);
+            return getTimelineAdherenceStatus(daysDifference);
+        }
+
+        // For upcoming releases, compare current date vs planned
+        long daysDifference =
+                (Instant.now().toEpochMilli() - plannedReleaseDate.toEpochMilli()) / (24 * 60 * 60 * 1000);
+        return getTimelineAdherenceStatus(daysDifference);
+    }
+
+    private TimelineAdherence getTimelineAdherenceStatus(long daysDifference) {
+        if (daysDifference <= 0) {
+            return TimelineAdherence.ON_SCHEDULE;
+        } else if (daysDifference < 14) {
+            return TimelineAdherence.DELAYED;
+        } else {
+            return TimelineAdherence.CRITICAL;
+        }
+    }
+
+    private List<RoadmapItem> applyGrouping(List<RoadmapItem> items, String groupBy) {
+        Map<String, List<RoadmapItem>> grouped =
+                switch (groupBy) {
+                    case "productcode" -> items.stream().collect(Collectors.groupingBy(this::getProductCodeFromItem));
+                    case "status" -> items.stream().collect(Collectors.groupingBy(item -> item.release()
+                            .status()));
+                    case "owner" -> items.stream()
+                            .collect(
+                                    Collectors.groupingBy(item -> item.release().owner() != null
+                                            ? item.release().owner()
+                                            : ""));
+                    default -> throw new IllegalArgumentException("Invalid groupBy value: " + groupBy);
+                };
+
+        // Flatten grouped results while maintaining sort order within each group
+        return grouped.values().stream().flatMap(List::stream).collect(Collectors.toList());
+    }
+
+    private String getProductCodeFromItem(RoadmapItem item) {
+        // Use product info from RoadmapRelease (no extra database query needed)
+        return item.release().product() != null ? item.release().product().code() : "";
+    }
+
+    private RoadmapSummary calculateSummary(List<RoadmapItem> roadmapItems) {
+        int totalReleases = roadmapItems.size();
+
+        long completedReleases = roadmapItems.stream()
+                .filter(item -> "COMPLETED".equals(item.release().status())
+                        || "RELEASED".equals(item.release().status()))
+                .count();
+
+        long draftReleases = roadmapItems.stream()
+                .filter(item -> "DRAFT".equals(item.release().status()))
+                .count();
+
+        int totalFeatures = roadmapItems.stream()
+                .mapToInt(item -> item.progressMetrics().totalFeatures())
+                .sum();
+
+        double overallCompletionPercentage =
+                totalReleases > 0 ? (double) completedReleases / totalReleases * 100.0 : 0.0;
+
+        return new RoadmapSummary(
+                totalReleases,
+                (int) completedReleases,
+                (int) draftReleases,
+                totalFeatures,
+                Math.round(overallCompletionPercentage * 100.0) / 100.0);
+    }
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/dtos/ReleaseRoadmapDto.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/dtos/ReleaseRoadmapDto.java
@@ -1,12 +1,12 @@
 package com.sivalabs.ft.features.domain.dtos;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.sivalabs.ft.features.domain.models.ReleaseStatus;
 import java.io.Serializable;
 import java.time.Instant;
 
-public record ReleaseDto(
+public record ReleaseRoadmapDto(
         Long id,
-        ProductDto product,
         String code,
         String description,
         ReleaseStatus status,
@@ -19,5 +19,7 @@ public record ReleaseDto(
         String createdBy,
         Instant createdAt,
         String updatedBy,
-        Instant updatedAt)
+        Instant updatedAt,
+        @JsonIgnore String productCode,
+        @JsonIgnore String productName)
         implements Serializable {}

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/FeatureMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/FeatureMapper.java
@@ -9,5 +9,6 @@ import org.mapstruct.Mapping;
 public interface FeatureMapper {
     @Mapping(target = "releaseCode", source = "release.code", defaultExpression = "java( null )")
     @Mapping(target = "isFavorite", ignore = true)
+    @Mapping(target = "makeFavorite", ignore = true)
     FeatureDto toDto(Feature feature);
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/mappers/ReleaseMapper.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/mappers/ReleaseMapper.java
@@ -4,7 +4,9 @@ import com.sivalabs.ft.features.domain.dtos.ReleaseDto;
 import com.sivalabs.ft.features.domain.entities.Release;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper(
+        componentModel = "spring",
+        uses = {ProductMapper.class})
 public interface ReleaseMapper {
     ReleaseDto toDto(Release release);
 }

--- a/src/main/java/com/sivalabs/ft/features/domain/models/RiskLevel.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/models/RiskLevel.java
@@ -1,0 +1,8 @@
+package com.sivalabs.ft.features.domain.models;
+
+public enum RiskLevel {
+    ZERO,
+    LOW,
+    MEDIUM,
+    HIGH
+}

--- a/src/main/java/com/sivalabs/ft/features/domain/models/TimelineAdherence.java
+++ b/src/main/java/com/sivalabs/ft/features/domain/models/TimelineAdherence.java
@@ -1,0 +1,7 @@
+package com.sivalabs.ft.features.domain.models;
+
+public enum TimelineAdherence {
+    ON_SCHEDULE,
+    DELAYED,
+    CRITICAL
+}

--- a/src/test/java/com/sivalabs/ft/features/api/controllers/RoadmapControllerIntegrationTests.java
+++ b/src/test/java/com/sivalabs/ft/features/api/controllers/RoadmapControllerIntegrationTests.java
@@ -1,0 +1,1326 @@
+package com.sivalabs.ft.features.api.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+
+import com.sivalabs.ft.features.AbstractIT;
+import com.sivalabs.ft.features.WithMockOAuth2User;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@WithMockOAuth2User
+public class RoadmapControllerIntegrationTests extends AbstractIT {
+
+    @Test
+    void shouldGetRoadmapWithoutFilters() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            // Validate response structure
+            assertThat(response).containsKeys("roadmapItems", "summary", "appliedFilters");
+
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(6);
+
+            // Validate each roadmap item has required structure
+            for (Map<String, Object> item : roadmapItems) {
+                assertThat(item).containsKeys("release", "progressMetrics", "healthIndicators", "features");
+
+                // Validate release has core fields with exact values
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+                assertThat(release.get("id")).isInstanceOf(Number.class);
+                assertThat(release.get("code")).isInstanceOf(String.class);
+                assertThat(release.get("status")).isIn("RELEASED", "PLANNED");
+                assertThat(release.get("createdAt")).isInstanceOf(String.class);
+            }
+
+            Map<String, Object> summary = (Map<String, Object>) response.get("summary");
+            assertThat(summary.get("totalReleases")).isEqualTo(6);
+            assertThat(summary.get("completedReleases")).isEqualTo(6); // All 6 releases are RELEASED
+            assertThat(summary.get("draftReleases")).isEqualTo(0);
+            assertThat(summary.get("totalFeatures")).isEqualTo(2); // Only 2 features in test data
+            assertThat(summary.get("overallCompletionPercentage")).isEqualTo(100.0); // All releases completed
+
+            Map<String, Object> appliedFilters = (Map<String, Object>) response.get("appliedFilters");
+            assertThat(appliedFilters).isNotNull();
+            assertThat(appliedFilters.get("productCodes")).isNull();
+            assertThat(appliedFilters.get("statuses")).isNull();
+            assertThat(appliedFilters.get("dateFrom")).isNull();
+            assertThat(appliedFilters.get("dateTo")).isNull();
+            assertThat(appliedFilters.get("groupBy")).isNull();
+            assertThat(appliedFilters.get("owner")).isNull();
+        });
+    }
+
+    @Test
+    void shouldValidateCompleteSpecificationCompliance() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            // Validate top-level structure
+            assertThat(response).containsKeys("roadmapItems", "summary", "appliedFilters");
+
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).isNotEmpty();
+
+            for (Map<String, Object> item : roadmapItems) {
+                // Validate roadmap item structure
+                assertThat(item).containsKeys("release", "progressMetrics", "healthIndicators", "features");
+
+                // Validate release object has ALL required fields and ONLY those fields
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+                assertThat(release)
+                        .containsKeys(
+                                "id",
+                                "code",
+                                "description",
+                                "status",
+                                "releasedAt",
+                                "plannedStartDate",
+                                "plannedReleaseDate",
+                                "actualReleaseDate",
+                                "owner",
+                                "notes",
+                                "createdBy",
+                                "createdAt",
+                                "updatedBy",
+                                "updatedAt");
+
+                // Validate field types
+                assertThat(release.get("id")).isInstanceOf(Number.class);
+                assertThat(release.get("code")).isInstanceOf(String.class);
+                assertThat(release.get("description")).isInstanceOf(String.class);
+                assertThat(release.get("status")).isInstanceOf(String.class);
+                assertThat(release.get("owner")).isInstanceOf(String.class);
+                assertThat(release.get("notes")).isInstanceOf(String.class);
+                assertThat(release.get("createdBy")).isInstanceOf(String.class);
+                assertThat(release.get("createdAt")).isInstanceOf(String.class);
+
+                // Validate progressMetrics structure
+                Map<String, Object> progressMetrics = (Map<String, Object>) item.get("progressMetrics");
+                assertThat(progressMetrics)
+                        .containsKeys(
+                                "totalFeatures",
+                                "completedFeatures",
+                                "inProgressFeatures",
+                                "newFeatures",
+                                "onHoldFeatures",
+                                "completionPercentage");
+
+                // Validate progressMetrics field types
+                assertThat(progressMetrics.get("totalFeatures")).isInstanceOf(Number.class);
+                assertThat(progressMetrics.get("completedFeatures")).isInstanceOf(Number.class);
+                assertThat(progressMetrics.get("inProgressFeatures")).isInstanceOf(Number.class);
+                assertThat(progressMetrics.get("newFeatures")).isInstanceOf(Number.class);
+                assertThat(progressMetrics.get("onHoldFeatures")).isInstanceOf(Number.class);
+                assertThat(progressMetrics.get("completionPercentage")).isInstanceOf(Number.class);
+
+                // Validate healthIndicators structure
+                Map<String, Object> healthIndicators = (Map<String, Object>) item.get("healthIndicators");
+                assertThat(healthIndicators).containsKeys("riskLevel", "timelineAdherence");
+                assertThat(healthIndicators.get("riskLevel")).isInstanceOf(String.class);
+                // timelineAdherence can be null
+
+                // Validate features array
+                List<Map<String, Object>> features = (List<Map<String, Object>>) item.get("features");
+                assertThat(features).isNotNull();
+
+                for (Map<String, Object> feature : features) {
+                    assertThat(feature)
+                            .containsKeys(
+                                    "id",
+                                    "code",
+                                    "title",
+                                    "description",
+                                    "status",
+                                    "releaseCode",
+                                    "assignedTo",
+                                    "createdBy",
+                                    "createdAt",
+                                    "updatedBy",
+                                    "updatedAt");
+
+                    // Validate feature field types
+                    assertThat(feature.get("id")).isInstanceOf(Number.class);
+                    assertThat(feature.get("code")).isInstanceOf(String.class);
+                    assertThat(feature.get("title")).isInstanceOf(String.class);
+                    assertThat(feature.get("description")).isInstanceOf(String.class);
+                    assertThat(feature.get("status")).isInstanceOf(String.class);
+                    assertThat(feature.get("releaseCode")).isInstanceOf(String.class);
+                    assertThat(feature.get("createdBy")).isInstanceOf(String.class);
+                    assertThat(feature.get("createdAt")).isInstanceOf(String.class);
+                }
+            }
+
+            // Validate summary structure
+            Map<String, Object> summary = (Map<String, Object>) response.get("summary");
+            assertThat(summary)
+                    .containsKeys(
+                            "totalReleases",
+                            "completedReleases",
+                            "draftReleases",
+                            "totalFeatures",
+                            "overallCompletionPercentage");
+
+            // Validate summary field types
+            assertThat(summary.get("totalReleases")).isInstanceOf(Number.class);
+            assertThat(summary.get("completedReleases")).isInstanceOf(Number.class);
+            assertThat(summary.get("draftReleases")).isInstanceOf(Number.class);
+            assertThat(summary.get("totalFeatures")).isInstanceOf(Number.class);
+            assertThat(summary.get("overallCompletionPercentage")).isInstanceOf(Number.class);
+
+            // Validate appliedFilters structure
+            Map<String, Object> appliedFilters = (Map<String, Object>) response.get("appliedFilters");
+            assertThat(appliedFilters)
+                    .containsKeys("productCodes", "statuses", "dateFrom", "dateTo", "groupBy", "owner");
+        });
+    }
+
+    @Test
+    void shouldGetRoadmapWithProductCodeFilter() throws Exception {
+        var result = mvc.get().uri("/api/roadmap?productCodes=intellij").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(2); // 2 IntelliJ IDEA releases
+
+            Map<String, Object> appliedFilters = (Map<String, Object>) response.get("appliedFilters");
+            List<String> productCodes = (List<String>) appliedFilters.get("productCodes");
+            assertThat(productCodes).containsExactly("intellij");
+
+            assertThat(appliedFilters.get("statuses")).isNull();
+            assertThat(appliedFilters.get("dateFrom")).isNull();
+            assertThat(appliedFilters.get("dateTo")).isNull();
+            assertThat(appliedFilters.get("groupBy")).isNull();
+            assertThat(appliedFilters.get("owner")).isNull();
+
+            // Validate specific IntelliJ releases
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+                String code = (String) release.get("code");
+                assertThat(code).isIn("IDEA-2024.2.3", "IDEA-2023.3.8");
+                assertThat(release.get("status")).isEqualTo("RELEASED");
+                assertThat(release.get("owner")).isIn("john.doe", "jane.smith");
+                assertThat(release.get("createdBy")).isEqualTo("admin");
+            }
+        });
+    }
+
+    @Test
+    void shouldGetRoadmapWithMultipleProductCodes() throws Exception {
+        var result = mvc.get()
+                .uri("/api/roadmap?productCodes=intellij&productCodes=goland")
+                .exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(3); // Filtered: 2 IntelliJ + 1 GoLand releases only
+
+            Map<String, Object> appliedFilters = (Map<String, Object>) response.get("appliedFilters");
+            List<String> productCodes = (List<String>) appliedFilters.get("productCodes");
+            assertThat(productCodes).hasSize(2).containsExactlyInAnyOrder("intellij", "goland");
+
+            // Validate all items have required release fields with specific values
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+
+                // Validate specific release codes for intellij and goland
+                String releaseCode = (String) release.get("code");
+                assertThat(releaseCode).isIn("IDEA-2024.2.3", "IDEA-2023.3.8", "GO-2024.2.3");
+                assertThat(release.get("status")).isEqualTo("RELEASED");
+                assertThat(release.get("owner")).isIn("john.doe", "jane.smith");
+                assertThat(release.get("createdBy")).isEqualTo("admin");
+
+                // Validate progressMetrics with expected values based on test data
+                Map<String, Object> progressMetrics = (Map<String, Object>) item.get("progressMetrics");
+                int totalFeatures = ((Number) progressMetrics.get("totalFeatures")).intValue();
+                assertThat(totalFeatures).isIn(0, 2); // Either 0 or 2 features based on actual data
+                assertThat(progressMetrics.get("onHoldFeatures")).isEqualTo(0); // No ON_HOLD features in test data
+
+                // Validate health indicators
+                Map<String, Object> healthIndicators = (Map<String, Object>) item.get("healthIndicators");
+                assertThat(healthIndicators.get("riskLevel")).isEqualTo("ZERO"); // No ON_HOLD features = ZERO risk
+            }
+        });
+    }
+
+    @Test
+    void shouldGetRoadmapWithStatusFilter() throws Exception {
+        var result = mvc.get().uri("/api/roadmap?statuses=RELEASED").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(6); // All 6 releases have RELEASED status in test data
+
+            Map<String, Object> appliedFilters = (Map<String, Object>) response.get("appliedFilters");
+            List<String> statuses = (List<String>) appliedFilters.get("statuses");
+            assertThat(statuses).containsExactly("RELEASED");
+
+            // Validate all items have RELEASED status and actual codes from test data
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+                assertThat(release.get("status")).isEqualTo("RELEASED");
+                String code = (String) release.get("code");
+                assertThat(code)
+                        .isIn(
+                                "IDEA-2024.2.3",
+                                "PY-2024.2.3",
+                                "WEB-2024.2.3",
+                                "RIDER-2024.2.6",
+                                "GO-2024.2.3",
+                                "IDEA-2023.3.8");
+            }
+        });
+    }
+
+    @Test
+    void shouldGetRoadmapWithMultipleStatuses() throws Exception {
+        var result =
+                mvc.get().uri("/api/roadmap?statuses=RELEASED&statuses=PLANNED").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(6); // All 6 releases are RELEASED in test data
+
+            Map<String, Object> appliedFilters = (Map<String, Object>) response.get("appliedFilters");
+            List<String> statuses = (List<String>) appliedFilters.get("statuses");
+            assertThat(statuses).hasSize(2).containsExactlyInAnyOrder("RELEASED", "PLANNED");
+
+            // Count actual statuses
+            long releasedCount = roadmapItems.stream()
+                    .filter(item -> "RELEASED".equals(((Map<String, Object>) item.get("release")).get("status")))
+                    .count();
+            long plannedCount = roadmapItems.stream()
+                    .filter(item -> "PLANNED".equals(((Map<String, Object>) item.get("release")).get("status")))
+                    .count();
+
+            assertThat(releasedCount).isEqualTo(6); // All releases are RELEASED
+            assertThat(plannedCount).isEqualTo(0); // No PLANNED releases in test data
+        });
+    }
+
+    @Test
+    void shouldGetRoadmapWithDateRangeFilter() throws Exception {
+        var result = mvc.get()
+                .uri("/api/roadmap?dateFrom=2024-01-01&dateTo=2025-12-31")
+                .exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems)
+                    .hasSize(5); // Only 5 releases fall within 2024-2025 range (IDEA-2023.3.8 is excluded)
+
+            Map<String, Object> appliedFilters = (Map<String, Object>) response.get("appliedFilters");
+            assertThat(appliedFilters.get("dateFrom")).isEqualTo("2024-01-01");
+            assertThat(appliedFilters.get("dateTo")).isEqualTo("2025-12-31");
+
+            // Validate that all returned releases are within date range
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+                String releaseDate = (String) release.get("releasedAt");
+                if (releaseDate != null) {
+                    assertThat(releaseDate).isGreaterThanOrEqualTo("2024-01-01");
+                    assertThat(releaseDate).isLessThanOrEqualTo("2025-12-31");
+                }
+            }
+        });
+    }
+
+    @Test
+    void shouldGetRoadmapWithOwnerFilter() throws Exception {
+        var result = mvc.get().uri("/api/roadmap?owner=john.doe").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(1); // 1 release owned by john.doe
+
+            Map<String, Object> appliedFilters = (Map<String, Object>) response.get("appliedFilters");
+            assertThat(appliedFilters.get("owner")).isEqualTo("john.doe");
+
+            // Validate all items have owner john.doe
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+                assertThat(release.get("owner")).isEqualTo("john.doe");
+            }
+        });
+    }
+
+    @Test
+    void shouldGetRoadmapWithGroupByProductCode() throws Exception {
+        var result = mvc.get().uri("/api/roadmap?groupBy=productCode").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(6); // All items returned, grouped by product
+
+            Map<String, Object> appliedFilters = (Map<String, Object>) response.get("appliedFilters");
+            assertThat(appliedFilters.get("groupBy")).isEqualTo("productCode");
+
+            // Validate specific values for each release
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+
+                // Validate specific release codes from actual test data
+                String code = (String) release.get("code");
+                assertThat(code)
+                        .isIn(
+                                "IDEA-2024.2.3",
+                                "PY-2024.2.3",
+                                "WEB-2024.2.3",
+                                "RIDER-2024.2.6",
+                                "GO-2024.2.3",
+                                "IDEA-2023.3.8");
+                assertThat(release.get("status")).isEqualTo("RELEASED");
+                assertThat(release.get("owner")).isIn("john.doe", "jane.smith");
+                assertThat(release.get("createdBy")).isEqualTo("admin");
+
+                // Validate progressMetrics with actual test data values
+                Map<String, Object> progressMetrics = (Map<String, Object>) item.get("progressMetrics");
+                int totalFeatures = ((Number) progressMetrics.get("totalFeatures")).intValue();
+                assertThat(totalFeatures).isIn(0, 2); // Either 0 or 2 features based on actual data
+                assertThat(progressMetrics.get("onHoldFeatures")).isEqualTo(0);
+
+                // Validate health indicators
+                Map<String, Object> healthIndicators = (Map<String, Object>) item.get("healthIndicators");
+                assertThat(healthIndicators.get("riskLevel")).isEqualTo("ZERO");
+
+                // Validate features array
+                List<Map<String, Object>> features = (List<Map<String, Object>>) item.get("features");
+                assertThat(features.size()).isEqualTo(totalFeatures);
+            }
+        });
+    }
+
+    @Test
+    void shouldGetRoadmapWithGroupByStatus() throws Exception {
+        var result = mvc.get().uri("/api/roadmap?groupBy=status").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(6); // All items returned, grouped by status
+
+            Map<String, Object> appliedFilters = (Map<String, Object>) response.get("appliedFilters");
+            assertThat(appliedFilters.get("groupBy")).isEqualTo("status");
+
+            // Validate status distribution (all RELEASED in original test data)
+            int releasedCount = 0;
+            int plannedCount = 0;
+
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+                String status = (String) release.get("status");
+
+                if ("RELEASED".equals(status)) {
+                    releasedCount++;
+                } else if ("PLANNED".equals(status)) {
+                    plannedCount++;
+                }
+            }
+
+            assertThat(releasedCount).isEqualTo(6); // All releases are RELEASED
+            assertThat(plannedCount).isEqualTo(0); // No PLANNED releases in test data
+        });
+    }
+
+    @Test
+    void shouldGetRoadmapWithGroupByOwner() throws Exception {
+        var result = mvc.get().uri("/api/roadmap?groupBy=owner").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(6); // All items returned, grouped by owner
+
+            Map<String, Object> appliedFilters = (Map<String, Object>) response.get("appliedFilters");
+            assertThat(appliedFilters.get("groupBy")).isEqualTo("owner");
+
+            // Validate owner distribution based on actual test data
+            int johnDoeCount = 0;
+            int janeSmithCount = 0;
+
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+                String owner = (String) release.get("owner");
+
+                switch (owner) {
+                    case "john.doe":
+                        johnDoeCount++;
+                        break;
+                    case "jane.smith":
+                        janeSmithCount++;
+                        break;
+                }
+            }
+
+            // Based on actual test data: john.doe has 1 release, jane.smith has 5 releases
+            assertThat(johnDoeCount).isEqualTo(1);
+            assertThat(janeSmithCount).isEqualTo(5);
+        });
+    }
+
+    @Test
+    void shouldGetRoadmapWithCombinedFilters() throws Exception {
+        var result = mvc.get()
+                .uri("/api/roadmap?productCodes=intellij&statuses=RELEASED&dateFrom=2024-01-01&owner=john.doe")
+                .exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(1); // john.doe owns IDEA-2024.2.3 which matches all filter criteria
+
+            Map<String, Object> appliedFilters = (Map<String, Object>) response.get("appliedFilters");
+            List<String> productCodes = (List<String>) appliedFilters.get("productCodes");
+            assertThat(productCodes).containsExactly("intellij");
+
+            List<String> statuses = (List<String>) appliedFilters.get("statuses");
+            assertThat(statuses).containsExactly("RELEASED");
+
+            assertThat(appliedFilters.get("dateFrom")).isEqualTo("2024-01-01");
+            assertThat(appliedFilters.get("owner")).isEqualTo("john.doe");
+
+            // Validate the returned item matches all filter criteria
+            Map<String, Object> item = roadmapItems.get(0);
+            Map<String, Object> release = (Map<String, Object>) item.get("release");
+            assertThat(release.get("code")).isEqualTo("IDEA-2024.2.3");
+            assertThat(release.get("owner")).isEqualTo("john.doe");
+            assertThat(release.get("status")).isEqualTo("RELEASED");
+        });
+    }
+
+    @Test
+    void shouldValidateProgressMetricsInResponse() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+
+            // Validate progressMetrics from roadmap items with exact values
+            int totalFeatures = 0;
+            int completedFeatures = 0;
+            int inProgressFeatures = 0;
+            int newFeatures = 0;
+            int onHoldFeatures = 0;
+
+            for (Map<String, Object> item : roadmapItems) {
+                List<Map<String, Object>> features = (List<Map<String, Object>>) item.get("features");
+                if (features != null) {
+                    for (Map<String, Object> feature : features) {
+                        String status = (String) feature.get("status");
+                        totalFeatures++;
+                        if ("COMPLETED".equals(status)) {
+                            completedFeatures++;
+                        } else if ("IN_PROGRESS".equals(status)) {
+                            inProgressFeatures++;
+                        } else if ("NEW".equals(status)) {
+                            newFeatures++;
+                        } else if ("ON_HOLD".equals(status)) {
+                            onHoldFeatures++;
+                        }
+                    }
+                }
+            }
+
+            // Validate exact feature counts based on actual test data
+            assertThat(totalFeatures).isEqualTo(2); // Only 2 features in test data
+            assertThat(completedFeatures).isEqualTo(0); // No COMPLETED features
+            assertThat(inProgressFeatures).isEqualTo(0); // No IN_PROGRESS features
+            assertThat(newFeatures).isEqualTo(2); // Both features are NEW
+            assertThat(onHoldFeatures).isEqualTo(0); // No ON_HOLD features
+
+            // Validate relationship constraints
+            assertThat(completedFeatures).isLessThanOrEqualTo(totalFeatures);
+            assertThat(inProgressFeatures).isLessThanOrEqualTo(totalFeatures);
+            assertThat(newFeatures).isLessThanOrEqualTo(totalFeatures);
+            assertThat(onHoldFeatures).isLessThanOrEqualTo(totalFeatures);
+            assertThat(completedFeatures + inProgressFeatures + newFeatures + onHoldFeatures)
+                    .isEqualTo(totalFeatures);
+        });
+    }
+
+    @Test
+    void shouldValidateHealthIndicatorsInResponse() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).isNotEmpty();
+
+            // Validate health indicators for all items
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> healthIndicators = (Map<String, Object>) item.get("healthIndicators");
+
+                // Risk level must be exact value from enum
+                String riskLevel = (String) healthIndicators.get("riskLevel");
+                assertThat(riskLevel).isEqualTo("ZERO"); // No ON_HOLD features = ZERO risk
+
+                // Timeline adherence can be DELAYED, ON_SCHEDULE, or CRITICAL based on actual release data
+                String timelineAdherence = (String) healthIndicators.get("timelineAdherence");
+                if (timelineAdherence != null) {
+                    assertThat(timelineAdherence).isIn("ON_SCHEDULE", "DELAYED", "CRITICAL");
+                }
+            }
+        });
+    }
+
+    @Test
+    void shouldValidateSummaryInResponse() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            Map<String, Object> summary = (Map<String, Object>) response.get("summary");
+
+            assertThat(summary.get("totalReleases")).isEqualTo(6);
+            assertThat(summary.get("completedReleases")).isEqualTo(6); // All 6 releases are RELEASED
+            assertThat(summary.get("draftReleases")).isEqualTo(0);
+            assertThat(summary.get("totalFeatures")).isEqualTo(2); // Only 2 features total
+            assertThat(summary.get("overallCompletionPercentage")).isEqualTo(100.0); // All releases completed = 100%
+        });
+    }
+
+    @Test
+    void shouldValidateReleaseFieldsInResponse() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            // Find the release that has features (IDEA-2023.3.8 has 2 features)
+            Map<String, Object> releaseWithFeatures = roadmapItems.stream()
+                    .filter(item -> {
+                        Map<String, Object> rel = (Map<String, Object>) item.get("release");
+                        String code = (String) rel.get("code");
+                        return "IDEA-2023.3.8".equals(code);
+                    })
+                    .findFirst()
+                    .orElse(null);
+
+            if (releaseWithFeatures != null) {
+                Map<String, Object> release = (Map<String, Object>) releaseWithFeatures.get("release");
+                String code = (String) release.get("code");
+                assertThat(code).isEqualTo("IDEA-2023.3.8");
+
+                String status = (String) release.get("status");
+                assertThat(status).isEqualTo("RELEASED");
+
+                List<Map<String, Object>> features = (List<Map<String, Object>>) releaseWithFeatures.get("features");
+                assertThat(features).hasSize(2);
+            }
+        });
+    }
+
+    // Validation Error Tests
+    @Test
+    void shouldReturnBadRequestForInvalidStatus() throws Exception {
+        var result = mvc.get().uri("/api/roadmap?statuses=INVALID_STATUS").exchange();
+        assertThat(result).hasStatus(400);
+    }
+
+    @Test
+    void shouldReturnBadRequestForInvalidGroupBy() throws Exception {
+        var result = mvc.get().uri("/api/roadmap?groupBy=invalidGroup").exchange();
+        assertThat(result).hasStatus(400);
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenDateFromIsAfterDateTo() throws Exception {
+        var result = mvc.get()
+                .uri("/api/roadmap?dateFrom=2025-12-31&dateTo=2024-01-01")
+                .exchange();
+        assertThat(result).hasStatus(400);
+    }
+
+    @Test
+    void shouldReturnBadRequestForInvalidDateFormat() throws Exception {
+        var result = mvc.get().uri("/api/roadmap?dateFrom=invalid-date").exchange();
+        assertThat(result).hasStatus(400);
+    }
+
+    @Test
+    void shouldAllowExtraQueryParameters() throws Exception {
+        var result = mvc.get()
+                .uri("/api/roadmap?extraParam=extraValue&anotherParam=anotherValue")
+                .exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(6); // Extra params ignored, returns all items
+        });
+    }
+
+    @Test
+    void shouldHandleEmptyResultsForNonExistentOwner() throws Exception {
+        var result = mvc.get().uri("/api/roadmap?owner=non.existent.user").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).isEmpty();
+
+            Map<String, Object> appliedFilters = (Map<String, Object>) response.get("appliedFilters");
+            assertThat(appliedFilters.get("owner")).isEqualTo("non.existent.user");
+        });
+    }
+
+    @Test
+    void shouldHandleCaseInsensitiveStatuses() throws Exception {
+        var result =
+                mvc.get().uri("/api/roadmap?statuses=released&statuses=planned").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(6); // Case-insensitive: all releases returned
+        });
+    }
+
+    @Test
+    void shouldHandleCaseInsensitiveGroupBy() throws Exception {
+        var result = mvc.get().uri("/api/roadmap?groupBy=PRODUCTCODE").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(6); // Case-insensitive groupBy returns all 6 items
+        });
+    }
+
+    // Sorting Tests
+    @Test
+    void shouldSortReleasesInDescendingOrderByDate() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(6);
+
+            // Verify releases are sorted in descending date order
+            for (int i = 0; i < roadmapItems.size() - 1; i++) {
+                Map<String, Object> currentRelease =
+                        (Map<String, Object>) roadmapItems.get(i).get("release");
+                Map<String, Object> nextRelease =
+                        (Map<String, Object>) roadmapItems.get(i + 1).get("release");
+
+                String currentSortingDate = (String)
+                        (currentRelease.get("actualReleaseDate") != null
+                                ? currentRelease.get("actualReleaseDate")
+                                : (currentRelease.get("releasedAt") != null
+                                        ? currentRelease.get("releasedAt")
+                                        : (currentRelease.get("plannedReleaseDate") != null
+                                                ? currentRelease.get("plannedReleaseDate")
+                                                : currentRelease.get("createdAt"))));
+
+                String nextSortingDate = (String)
+                        (nextRelease.get("actualReleaseDate") != null
+                                ? nextRelease.get("actualReleaseDate")
+                                : (nextRelease.get("releasedAt") != null
+                                        ? nextRelease.get("releasedAt")
+                                        : (nextRelease.get("plannedReleaseDate") != null
+                                                ? nextRelease.get("plannedReleaseDate")
+                                                : nextRelease.get("createdAt"))));
+
+                // Validate both have dates and are in descending order
+                assertThat(currentSortingDate).isNotNull();
+                assertThat(nextSortingDate).isNotNull();
+                // Current item should have date >= next item (descending order)
+                assertThat(currentSortingDate).isGreaterThanOrEqualTo(nextSortingDate);
+            }
+        });
+    }
+
+    @Test
+    void shouldMaintainSortingWithinGroupBy() throws Exception {
+        var result = mvc.get().uri("/api/roadmap?groupBy=productCode").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+            assertThat(roadmapItems).hasSize(6);
+
+            // Validate that items are properly structured and have all required fields
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+
+                // Validate all required fields are present
+                assertThat(release.get("id")).isNotNull();
+                assertThat(release.get("code")).isNotNull();
+                assertThat(release.get("description")).isNotNull();
+                assertThat(release.get("status")).isNotNull();
+                assertThat(release.get("owner")).isNotNull();
+                assertThat(release.get("createdBy")).isNotNull();
+                assertThat(release.get("createdAt")).isNotNull();
+
+                // Validate complete structure
+                assertThat(item).containsKeys("release", "progressMetrics", "healthIndicators", "features");
+
+                // Validate progressMetrics structure
+                Map<String, Object> progressMetrics = (Map<String, Object>) item.get("progressMetrics");
+                assertThat(progressMetrics)
+                        .containsKeys(
+                                "totalFeatures",
+                                "completedFeatures",
+                                "inProgressFeatures",
+                                "newFeatures",
+                                "onHoldFeatures",
+                                "completionPercentage");
+
+                // Validate healthIndicators structure
+                Map<String, Object> healthIndicators = (Map<String, Object>) item.get("healthIndicators");
+                assertThat(healthIndicators).containsKeys("riskLevel", "timelineAdherence");
+
+                // Validate features array exists
+                assertThat(item.get("features")).isNotNull();
+            }
+        });
+    }
+
+    // Health Indicators - Risk Level Tests
+    @Test
+    void shouldCalculateRiskLevelZeroWhenNoFeaturesOnHold() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+
+            // Check any release with features to verify risk level calculation
+            Map<String, Object> releaseWithFeatures = roadmapItems.stream()
+                    .filter(item -> {
+                        List<Map<String, Object>> features = (List<Map<String, Object>>) item.get("features");
+                        return features != null && !features.isEmpty();
+                    })
+                    .findFirst()
+                    .orElseThrow();
+
+            Map<String, Object> healthIndicators = (Map<String, Object>) releaseWithFeatures.get("healthIndicators");
+            Object riskLevel = healthIndicators.get("riskLevel");
+            assertThat(riskLevel).isIn("ZERO", "LOW", "MEDIUM", "HIGH");
+        });
+    }
+
+    @Test
+    void shouldCalculateRiskLevelBasedOnOnHoldPercentage() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+
+            // Verify risk levels are calculated correctly
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> healthIndicators = (Map<String, Object>) item.get("healthIndicators");
+                Map<String, Object> progressMetrics = (Map<String, Object>) item.get("progressMetrics");
+
+                String riskLevel = (String) healthIndicators.get("riskLevel");
+                int totalFeatures = (Integer) progressMetrics.get("totalFeatures");
+                int onHoldFeatures = (Integer) progressMetrics.get("onHoldFeatures");
+
+                // Validate risk level matches percentage
+                if (totalFeatures > 0) {
+                    double onHoldPercentage = (onHoldFeatures * 100.0) / totalFeatures;
+
+                    if (onHoldFeatures == 0) {
+                        assertThat(riskLevel).isEqualTo("ZERO");
+                    } else if (onHoldPercentage < 10) {
+                        assertThat(riskLevel).isEqualTo("LOW");
+                    } else if (onHoldPercentage <= 30) {
+                        assertThat(riskLevel).isEqualTo("MEDIUM");
+                    } else {
+                        assertThat(riskLevel).isEqualTo("HIGH");
+                    }
+                } else {
+                    assertThat(riskLevel).isEqualTo("ZERO");
+                }
+            }
+        });
+    }
+
+    @Test
+    void shouldCalculateTimelineAdherenceForUpcomingReleases() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+
+            // Verify roadmap items are returned with valid timeline adherence values
+            assertThat(roadmapItems).isNotEmpty();
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> healthIndicators = (Map<String, Object>) item.get("healthIndicators");
+                Object timelineAdherence = healthIndicators.get("timelineAdherence");
+                // Can be null, ON_SCHEDULE, DELAYED, or CRITICAL
+                if (timelineAdherence != null) {
+                    assertThat(timelineAdherence).isIn("ON_SCHEDULE", "DELAYED", "CRITICAL");
+                }
+            }
+        });
+    }
+
+    @Test
+    void shouldValidateTimelineAdherenceValues() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> healthIndicators = (Map<String, Object>) item.get("healthIndicators");
+                String timelineAdherence = (String) healthIndicators.get("timelineAdherence");
+
+                // Timeline adherence must be one of the valid values or null
+                if (timelineAdherence != null) {
+                    assertThat(timelineAdherence).isIn("ON_SCHEDULE", "DELAYED", "CRITICAL");
+                }
+            }
+        });
+    }
+
+    @Test
+    void shouldFilterByDateToUsingCorrectSortingDateField() throws Exception {
+        var result = mvc.get().uri("/api/roadmap?dateTo=2024-02-20").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+
+            // Verify all returned items have sorting date <= 2024-02-20
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+
+                // Get the date used for sorting (first non-null)
+                String sortingDate = (String)
+                        (release.get("actualReleaseDate") != null
+                                ? release.get("actualReleaseDate")
+                                : (release.get("releasedAt") != null
+                                        ? release.get("releasedAt")
+                                        : (release.get("plannedReleaseDate") != null
+                                                ? release.get("plannedReleaseDate")
+                                                : release.get("createdAt"))));
+
+                // Dates come back with timestamps, compare only the date part
+                if (sortingDate != null) {
+                    String dateOnly = sortingDate.split("T")[0];
+                    assertThat(dateOnly).isLessThanOrEqualTo("2024-02-20");
+                }
+            }
+        });
+    }
+
+    @Test
+    void shouldReturnNullTimelineAdherenceWhenPlannedReleaseDateMissing() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+
+            // Find releases without plannedReleaseDate
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+                Map<String, Object> healthIndicators = (Map<String, Object>) item.get("healthIndicators");
+
+                Object plannedReleaseDate = release.get("plannedReleaseDate");
+                String timelineAdherence = (String) healthIndicators.get("timelineAdherence");
+
+                // STRICT: If no plannedReleaseDate, timelineAdherence MUST be null
+                if (plannedReleaseDate == null) {
+                    assertThat(timelineAdherence)
+                            .as("TimelineAdherence must be null when plannedReleaseDate is missing")
+                            .isNull();
+                }
+            }
+        });
+    }
+
+    @Test
+    void shouldReturnOnScheduleWhenActualReleaseDateBeforePlanned() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+
+            // Validate ON_SCHEDULE for completed releases that met deadline
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+                Map<String, Object> healthIndicators = (Map<String, Object>) item.get("healthIndicators");
+
+                String plannedReleaseDate = (String) release.get("plannedReleaseDate");
+                String actualReleaseDate = (String) release.get("actualReleaseDate");
+                String releasedAt = (String) release.get("releasedAt");
+                String timelineAdherence = (String) healthIndicators.get("timelineAdherence");
+
+                // If has plannedReleaseDate and actualReleaseDate or releasedAt
+                if (plannedReleaseDate != null && (actualReleaseDate != null || releasedAt != null)) {
+                    String releaseDate = actualReleaseDate != null ? actualReleaseDate : releasedAt;
+
+                    // Extract date parts for comparison
+                    String plannedDate = plannedReleaseDate.split("T")[0];
+                    String releaseDateOnly = releaseDate.split("T")[0];
+
+                    // STRICT: If release is on or before planned date, must be ON_SCHEDULE
+                    if (releaseDateOnly.compareTo(plannedDate) <= 0) {
+                        assertThat(timelineAdherence)
+                                .as(
+                                        "Release on %s should be ON_SCHEDULE when planned for %s",
+                                        releaseDateOnly, plannedDate)
+                                .isEqualTo("ON_SCHEDULE");
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    void shouldReturnDelayedWhenDelay0To13Days() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+
+            // Calculate delays and validate DELAYED status (0-13 days)
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+                Map<String, Object> healthIndicators = (Map<String, Object>) item.get("healthIndicators");
+
+                String plannedReleaseDate = (String) release.get("plannedReleaseDate");
+                String actualReleaseDate = (String) release.get("actualReleaseDate");
+                String releasedAt = (String) release.get("releasedAt");
+                String timelineAdherence = (String) healthIndicators.get("timelineAdherence");
+
+                if (plannedReleaseDate != null && (actualReleaseDate != null || releasedAt != null)) {
+                    String releaseDate = actualReleaseDate != null ? actualReleaseDate : releasedAt;
+
+                    String plannedDate = plannedReleaseDate.split("T")[0];
+                    String releaseDateOnly = releaseDate.split("T")[0];
+
+                    // If release is after planned date, check delay
+                    if (releaseDateOnly.compareTo(plannedDate) > 0) {
+                        // Calculate days delay
+                        long delayDays = java.time.temporal.ChronoUnit.DAYS.between(
+                                java.time.LocalDate.parse(plannedDate), java.time.LocalDate.parse(releaseDateOnly));
+
+                        // STRICT: 0-13 days delay = DELAYED
+                        if (delayDays >= 0 && delayDays < 14) {
+                            assertThat(timelineAdherence)
+                                    .as("Release %d days late should be DELAYED", delayDays)
+                                    .isEqualTo("DELAYED");
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    void shouldReturnCriticalWhenDelay14DaysOrMore() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+
+            // Calculate delays and validate CRITICAL status (14+ days)
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+                Map<String, Object> healthIndicators = (Map<String, Object>) item.get("healthIndicators");
+
+                String plannedReleaseDate = (String) release.get("plannedReleaseDate");
+                String actualReleaseDate = (String) release.get("actualReleaseDate");
+                String releasedAt = (String) release.get("releasedAt");
+                String timelineAdherence = (String) healthIndicators.get("timelineAdherence");
+
+                if (plannedReleaseDate != null && (actualReleaseDate != null || releasedAt != null)) {
+                    String releaseDate = actualReleaseDate != null ? actualReleaseDate : releasedAt;
+
+                    String plannedDate = plannedReleaseDate.split("T")[0];
+                    String releaseDateOnly = releaseDate.split("T")[0];
+
+                    // If release is after planned date, check delay
+                    if (releaseDateOnly.compareTo(plannedDate) > 0) {
+                        // Calculate days delay
+                        long delayDays = java.time.temporal.ChronoUnit.DAYS.between(
+                                java.time.LocalDate.parse(plannedDate), java.time.LocalDate.parse(releaseDateOnly));
+
+                        // STRICT: 14+ days delay = CRITICAL
+                        if (delayDays >= 14) {
+                            assertThat(timelineAdherence)
+                                    .as("Release %d days late should be CRITICAL", delayDays)
+                                    .isEqualTo("CRITICAL");
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    void shouldValidate14DayBoundary() throws Exception {
+        var result = mvc.get().uri("/api/roadmap").exchange();
+
+        assertThat(result).hasStatusOk().bodyJson().convertTo(Map.class).satisfies(response -> {
+            List<Map<String, Object>> roadmapItems = (List<Map<String, Object>>) response.get("roadmapItems");
+
+            boolean found13DayDelay = false;
+            boolean found14DayDelay = false;
+
+            // Look for releases that can validate the 14-day boundary
+            for (Map<String, Object> item : roadmapItems) {
+                Map<String, Object> release = (Map<String, Object>) item.get("release");
+                Map<String, Object> healthIndicators = (Map<String, Object>) item.get("healthIndicators");
+
+                String plannedReleaseDate = (String) release.get("plannedReleaseDate");
+                String actualReleaseDate = (String) release.get("actualReleaseDate");
+                String releasedAt = (String) release.get("releasedAt");
+                String timelineAdherence = (String) healthIndicators.get("timelineAdherence");
+
+                if (plannedReleaseDate != null && (actualReleaseDate != null || releasedAt != null)) {
+                    String releaseDate = actualReleaseDate != null ? actualReleaseDate : releasedAt;
+
+                    String plannedDate = plannedReleaseDate.split("T")[0];
+                    String releaseDateOnly = releaseDate.split("T")[0];
+
+                    if (releaseDateOnly.compareTo(plannedDate) > 0) {
+                        long delayDays = java.time.temporal.ChronoUnit.DAYS.between(
+                                java.time.LocalDate.parse(plannedDate), java.time.LocalDate.parse(releaseDateOnly));
+
+                        if (delayDays == 13) {
+                            found13DayDelay = true;
+                            assertThat(timelineAdherence)
+                                    .as("13-day delay should be DELAYED, not CRITICAL")
+                                    .isEqualTo("DELAYED");
+                        } else if (delayDays == 14) {
+                            found14DayDelay = true;
+                            assertThat(timelineAdherence)
+                                    .as("14-day delay should be CRITICAL")
+                                    .isEqualTo("CRITICAL");
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    // CSV Export Tests
+    @Test
+    void shouldExportRoadmapAsCsv() throws Exception {
+        var result = mvc.get().uri("/api/roadmap/export?format=CSV").exchange();
+
+        assertThat(result).hasStatusOk().hasContentType("text/csv").headers().satisfies(headers -> {
+            String headerValue = headers.getFirst("Content-Disposition");
+            assertThat(headerValue).startsWith("attachment;");
+            assertThat(headerValue).contains("filename=\"Roadmap_");
+            assertThat(headerValue).endsWith(".csv\"");
+        });
+
+        assertThat(result).body().asString().satisfies(content -> {
+            String[] lines = content.split("\n");
+            assertThat(lines.length).isEqualTo(7); // Header + 6 data rows
+
+            // Validate exact header with all 18 columns (no quotes)
+            String expectedHeader =
+                    "Product Code,Product Name,Release Code,Release Description,Release Status,Released At,Planned Start Date,Planned Release Date,Actual Release Date,Owner,Total Features,Completed Features,In Progress Features,New Features,On Hold Features,Completion Percentage,Timeline Adherence,Risk Level";
+            assertThat(lines[0]).isEqualTo(expectedHeader);
+        });
+    }
+
+    @Test
+    void shouldExportRoadmapAsCsvWithFilters() throws Exception {
+        var result = mvc.get()
+                .uri("/api/roadmap/export?format=CSV&productCodes=intellij&statuses=RELEASED")
+                .exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .hasContentType("text/csv")
+                .body()
+                .asString()
+                .satisfies(content -> {
+                    String[] lines = content.split("\n");
+                    assertThat(lines.length).isEqualTo(3); // Header + 2 RELEASED intellij releases
+
+                    // Validate exact header (no quotes)
+                    String expectedHeader =
+                            "Product Code,Product Name,Release Code,Release Description,Release Status,Released At,Planned Start Date,Planned Release Date,Actual Release Date,Owner,Total Features,Completed Features,In Progress Features,New Features,On Hold Features,Completion Percentage,Timeline Adherence,Risk Level";
+                    assertThat(lines[0]).isEqualTo(expectedHeader);
+
+                    // Validate first data row
+                    String[] firstRow = lines[1].split(",");
+                    assertThat(firstRow[0]).isEqualTo("intellij");
+                    assertThat(firstRow[1]).isEqualTo("IntelliJ IDEA");
+                    assertThat(firstRow[4]).isEqualTo("RELEASED");
+                });
+    }
+
+    @Test
+    void shouldHandleCaseInsensitiveCsvFormat() throws Exception {
+        var result = mvc.get().uri("/api/roadmap/export?format=csv").exchange();
+        assertThat(result).hasStatusOk().hasContentType("text/csv");
+    }
+
+    // PDF Export Tests
+    @Test
+    void shouldExportRoadmapAsPdf() throws Exception {
+        var result = mvc.get().uri("/api/roadmap/export?format=PDF").exchange();
+
+        assertThat(result).hasStatusOk().satisfies(response -> {
+            var contentType = response.getMvcResult().getResponse().getContentType();
+            assertThat(contentType).contains("application/pdf");
+
+            var contentDisposition = response.getMvcResult().getResponse().getHeader("Content-Disposition");
+            // Validate filename format: Roadmap_yyyyMMddHHmmss.pdf
+            assertThat(contentDisposition).matches(".*Roadmap_\\d{14}\\.pdf.*");
+
+            // Verify PDF content has data
+            var content = response.getMvcResult().getResponse().getContentAsByteArray();
+            assertThat(content.length).isGreaterThan(0);
+        });
+    }
+
+    @Test
+    void shouldExportRoadmapAsPdfWithFilters() throws Exception {
+        var result = mvc.get()
+                .uri(
+                        "/api/roadmap/export?format=PDF&productCodes=intellij&productCodes=goland&dateFrom=2024-01-01&dateTo=2025-12-31")
+                .exchange();
+
+        assertThat(result).hasStatusOk().satisfies(response -> {
+            var content = response.getMvcResult().getResponse().getContentAsByteArray();
+            assertThat(content.length).isGreaterThan(0);
+            // PDF magic number validation
+            assertThat(content[0]).isEqualTo((byte) 0x25); // %
+            assertThat(content[1]).isEqualTo((byte) 0x50); // P
+            assertThat(content[2]).isEqualTo((byte) 0x44); // D
+            assertThat(content[3]).isEqualTo((byte) 0x46); // F
+        });
+    }
+
+    @Test
+    void shouldHandleCaseInsensitivePdfFormat() throws Exception {
+        var result = mvc.get().uri("/api/roadmap/export?format=pdf").exchange();
+        assertThat(result).hasStatusOk().satisfies(response -> {
+            var contentType = response.getMvcResult().getResponse().getContentType();
+            assertThat(contentType).contains("application/pdf");
+        });
+    }
+
+    // File Naming Tests
+    @Test
+    void shouldGenerateCorrectFileName() throws Exception {
+        var result = mvc.get().uri("/api/roadmap/export?format=CSV").exchange();
+
+        assertThat(result).hasStatusOk().headers().satisfies(headers -> {
+            String headerValue = headers.getFirst("Content-Disposition");
+            assertThat(headerValue).matches(".*filename=\"Roadmap_\\d{14}\\.csv\".*");
+        });
+    }
+
+    @Test
+    void shouldGenerateCorrectPdfFileName() throws Exception {
+        var result = mvc.get().uri("/api/roadmap/export?format=PDF").exchange();
+
+        assertThat(result).hasStatusOk().headers().satisfies(headers -> {
+            String headerValue = headers.getFirst("Content-Disposition");
+            assertThat(headerValue).matches(".*filename=\"Roadmap_\\d{14}\\.pdf\".*");
+        });
+    }
+
+    // Export Validation Error Tests
+    @Test
+    void shouldReturnBadRequestWhenFormatIsMissing() throws Exception {
+        var result = mvc.get().uri("/api/roadmap/export").exchange();
+        assertThat(result).hasStatus(400);
+    }
+
+    @Test
+    void shouldReturnBadRequestForInvalidFormat() throws Exception {
+        var result = mvc.get().uri("/api/roadmap/export?format=INVALID").exchange();
+        assertThat(result).hasStatus(400);
+    }
+
+    @Test
+    void shouldReturnBadRequestForEmptyFormat() throws Exception {
+        var result = mvc.get().uri("/api/roadmap/export?format=").exchange();
+        assertThat(result).hasStatus(400);
+    }
+
+    @Test
+    void shouldReturnBadRequestForInvalidStatusInExport() throws Exception {
+        var result = mvc.get()
+                .uri("/api/roadmap/export?format=CSV&statuses=INVALID_STATUS")
+                .exchange();
+        assertThat(result).hasStatus(400);
+    }
+
+    @Test
+    void shouldReturnBadRequestForInvalidGroupByInExport() throws Exception {
+        var result = mvc.get()
+                .uri("/api/roadmap/export?format=PDF&groupBy=invalidGroup")
+                .exchange();
+        assertThat(result).hasStatus(400);
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenDateFromIsAfterDateToInExport() throws Exception {
+        var result = mvc.get()
+                .uri("/api/roadmap/export?format=CSV&dateFrom=2025-12-31&dateTo=2024-01-01")
+                .exchange();
+        assertThat(result).hasStatus(400);
+    }
+
+    // Export Filter Application Tests
+    @Test
+    void shouldApplyAllFiltersToExport() throws Exception {
+        var result = mvc.get()
+                .uri(
+                        "/api/roadmap/export?format=CSV&productCodes=intellij&statuses=RELEASED&dateFrom=2024-01-01&dateTo=2024-12-31&groupBy=productCode&owner=john.doe")
+                .exchange();
+        assertThat(result).hasStatusOk().hasContentType("text/csv");
+    }
+
+    @Test
+    void shouldHandleEmptyResultsInExport() throws Exception {
+        var result = mvc.get()
+                .uri("/api/roadmap/export?format=CSV&owner=non.existent.user")
+                .exchange();
+
+        assertThat(result).hasStatusOk().body().asString().satisfies(content -> {
+            String[] lines = content.split("\n");
+            assertThat(lines.length).isEqualTo(1);
+            String headerLine = lines[0];
+            assertThat(headerLine).contains("Product Code");
+            assertThat(headerLine).contains("Product Name");
+            assertThat(headerLine).contains("Release Code");
+        });
+    }
+
+    // Performance Tests (basic timing validation)
+    @Test
+    void shouldCompleteExportWithinTimeLimit() throws Exception {
+        long startTime = System.currentTimeMillis();
+        var result = mvc.get().uri("/api/roadmap/export?format=CSV").exchange();
+        long endTime = System.currentTimeMillis();
+        long duration = endTime - startTime;
+
+        assertThat(result).hasStatusOk();
+        assertThat(duration).isBetween(0L, 2000L);
+    }
+
+    // Export Sorting Tests
+    @Test
+    void shouldExportWithSameSortingAsRoadmapApi() throws Exception {
+        var result = mvc.get().uri("/api/roadmap/export?format=CSV").exchange();
+
+        assertThat(result)
+                .hasStatusOk()
+                .hasContentType("text/csv")
+                .body()
+                .asString()
+                .satisfies(content -> {
+                    String[] lines = content.split("\n");
+                    assertThat(lines.length).isEqualTo(7); // Header + 6 data rows
+
+                    // Verify first row contains a release code
+                    assertThat(lines[1]).isNotEmpty();
+
+                    // Verify dates are in descending order
+                    // Index 8 = Actual Release Date
+                    String[] firstDataRow = lines[1].split(",");
+                    String[] secondDataRow = lines[2].split(",");
+                    String firstActualDate = firstDataRow[8];
+                    String secondActualDate = secondDataRow[8];
+
+                    // If both have actual dates, verify order
+                    if (!firstActualDate.isEmpty() && !secondActualDate.isEmpty()) {
+                        assertThat(firstActualDate).isGreaterThanOrEqualTo(secondActualDate);
+                    }
+                });
+    }
+}

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -12,13 +12,13 @@ insert into products (id, code, prefix, name, description, image_url, disabled, 
 (5, 'rider','RIDER','Rider', 'JetBrains IDE for .NET', 'https://resources.jetbrains.com/storage/products/company/brand/logos/Rider.png',false, 'admin','2024-03-01 00:00:00')
 ;
 
-insert into releases (id, product_id, code, description, status, created_by, created_at) values
-(1, 1, 'IDEA-2023.3.8', 'IntelliJ IDEA 2023.3.8', 'RELEASED', 'admin','2023-03-25'),
-(2, 1, 'IDEA-2024.2.3', 'IntelliJ IDEA 2024.2.4', 'RELEASED', 'admin','2024-02-25'),
-(3, 2, 'GO-2024.2.3', 'GoLand 2024.2.4', 'RELEASED', 'admin','2024-02-15'),
-(4, 3, 'WEB-2024.2.3', 'WebStorm 2024.2.4', 'RELEASED', 'admin','2024-02-20'),
-(5, 4, 'PY-2024.2.3', 'PyCharm 2024.2.4', 'RELEASED', 'admin','2024-02-20'),
-(6, 5, 'RIDER-2024.2.6', 'Rider 2024.2.6', 'RELEASED', 'admin','2024-02-16')
+insert into releases (id, product_id, code, description, status, planned_start_date, planned_release_date, actual_release_date, owner, notes, created_by, created_at, updated_by, updated_at) values
+(1, 1, 'IDEA-2023.3.8', 'IntelliJ IDEA 2023.3.8 - Bug fixes and performance improvements', 'RELEASED', '2023-10-01 09:00:00', '2023-11-15 17:00:00', '2023-12-01 10:00:00', 'jane.smith', 'Stable release with critical bug fixes', 'admin','2023-03-25 00:00:00', 'jane.smith', '2023-12-01 10:30:00'),
+(2, 1, 'IDEA-2024.2.3', 'IntelliJ IDEA 2024.2.4 - New features and improvements', 'RELEASED', '2024-01-10 09:00:00', '2024-02-20 17:00:00', '2024-02-25 14:00:00', 'john.doe', 'Major release with new AI-powered features', 'admin','2024-02-25 00:00:00', 'john.doe', '2024-02-25 14:30:00'),
+(3, 2, 'GO-2024.2.3', 'GoLand 2024.2.4 - Enhanced tooling', 'RELEASED', '2024-01-05 09:00:00', '2024-02-10 17:00:00', '2024-02-15 11:00:00', 'jane.smith', 'Enhanced debugging and profiling tools', 'admin','2024-02-15 00:00:00', 'jane.smith', '2024-02-15 11:30:00'),
+(4, 3, 'WEB-2024.2.3', 'WebStorm 2024.2.4 - Web development tools', 'RELEASED', '2024-01-08 09:00:00', '2024-02-15 17:00:00', '2024-02-20 09:00:00', 'jane.smith', 'Improved TypeScript and React support', 'admin','2024-02-20 00:00:00', 'jane.smith', '2024-02-20 09:30:00'),
+(5, 4, 'PY-2024.2.3', 'PyCharm 2024.2.4 - Python development', 'RELEASED', '2024-01-12 09:00:00', '2024-02-18 17:00:00', '2024-02-20 13:00:00', 'jane.smith', 'Enhanced data science and ML support', 'admin','2024-02-20 00:00:00', 'jane.smith', '2024-02-20 13:30:00'),
+(6, 5, 'RIDER-2024.2.6', 'Rider 2024.2.6 - .NET development', 'RELEASED', '2024-01-14 09:00:00', '2024-02-20 17:00:00', '2024-02-16 15:00:00', 'jane.smith', 'Improved C# and .NET framework support', 'admin','2024-02-16 00:00:00', 'jane.smith', '2024-02-16 15:30:00')
 ;
 
 insert into features (id, product_id, release_id, code, title, description, status, created_by, assigned_to, created_at) values


### PR DESCRIPTION
Issue reference: https://github.com/dpaia/feature-service/issues/127

## Objective

Implement API endpoints and data aggregation logic to support roadmap visualization, release dashboards, and comprehensive reporting.

## Requirements

### 1. Roadmap API

`GET /api/roadmap` - Get product roadmap with releases, features, progress metrics and health indicators.

#### Sorting:
Releases in the response should be sorted in descending order by date, 
that is taken from the first of the following fields containing a non-null value:
1. `actualReleaseDate`
2. `releasedAt`
3. `plannedReleaseDate`
4. `createdAt`

#### Filters:
Support filters as query parameters:
  - `productCodes` : `string[]` (optional) - list of product codes to filter releases by
  - `statuses` :  `string[]` (optional) - list of release statuses to filter releases by
    (e.g., `DRAFT`, `PLANNED`, `IN_PROGRESS` etc.)
  - `dateFrom` : iso date (optional) - filter releases by the same date field as used for sorting above (inclusive)
  - `dateTo` : iso date (optional)
  - `groupBy` : `productCode | status | owner` (optional) - group releases by the specified field, keep same sorting within each group.
  - `owner` : string (optional) - return releases for specified owner only
    - return empty results if such user does not exist or doesn't own any releases

#### Response:
```
{
  "roadmapItems": [
    {
      "release": {
        "id": Long,
        "code": String,
        "description": String,
        "status": String,
        "releasedAt": DateTime,
        "plannedStartDate": DateTime,
        "plannedReleaseDate": DateTime,
        "actualReleaseDate": DateTime,
        "owner": String,
        "notes": String,
        "createdBy": String,
        "createdAt": DateTime,
        "updatedBy": String,
        "updatedAt": DateTime
      },
      "progressMetrics": {
        "totalFeatures": Integer,
        "completedFeatures": Integer,
        "inProgressFeatures": Integer,
        "newFeatures": Integer,
        "onHoldFeatures": Integer,
        "completionPercentage": Double
      },
      "healthIndicators": {
        "riskLevel": String,
        "timelineAdherence": String
      },
      "features": [
        {
          "id": Long,
          "code": String,
          "title": String,
          "description": String,
          "status": String,
          "releaseCode": String,
          "assignedTo": String,
          "createdBy": String,
          "createdAt": DateTime,
          "updatedBy": String,
          "updatedAt": DateTime
        }
      ]
    }
  ],
  "summary": {
    "totalReleases": Integer,
    "completedReleases": Integer,
    "draftReleases": Integer,
    "totalFeatures": Integer,
    "overallCompletionPercentage": Double
  },
  "appliedFilters": {
    "productCodes": String[],
    "statuses": String[],
    "dateFrom": LocalDate,
    "dateTo": LocalDate,
    "groupBy": String,
    "owner": String
  }
}
```

##### Health Indicators:
- `riskLevel` is calculated based on percentage of features in the release in status `ON_HOLD`, and can be one of the following:
  - `ZERO`(0 features on hold)
  - `LOW` (<10% features on hold)
  - `MEDIUM` (>10%)
  - `HIGH` (>30%)
- `timelineAdherence` is calculated based on how many days are left from now until `plannedReleaseDate` for upcoming releases,
  or by comparing `actualReleaseDate` (with fallback to `releasedAt`) vs `plannedReleaseDate` for finished releases.
  It can be one of the following: 
  - null - if `plannedReleaseDate` is missing
  - `ON_SCHEDULE` - if either `actualReleaseDate` or `releasedAt` is set and is before or on the planned release date.
    - if both dates are missing, compare current date to planned release date.
  - `DELAYED` - if we are past the planned release date, but delay is less than 14 days
    - apply same field selection logic
  - `CRITICAL` - 14+ days delay

#### Validation:
Return 400 when:
- query parameters don't match expected filter types
  - ignore and allow extra query parameters in the request, that are not on the list of supported filters
- list of statuses contains incorrect status values (case-insensitive)
- `dateFrom` is after `dateTo`
- `groupBy` value is not on the list of supported values (case-insensitive)

### 2. Export API

`GET /api/roadmap/export?format=CSV|PDF` - Export roadmap as a file

- Support all the same filters and apply the same sorting as in the roadmap API
- `format` parameter is mandatory; allowed values are `CSV` and `PDF` (case-insensitive)
- Exported file name should be `Roadmap_{timestamp in yyyyMMddHHmmss format}.csv/pdf`
- CSV file should contain the following columns:
  - Product Code
  - Product Name
  - Release Code
  - Release Description
  - Release Status
  - Released At
  - Planned Start Date
  - Planned Release Date
  - Actual Release Date
  - Owner
  - Total Features
  - Completed Features
  - In Progress Features
  - New Features
  - On Hold Features
  - Completion Percentage
  - Timeline Adherence
  - Risk Level
- PDF export should contain the same data in a readable tabular format

## Implementation
Service Layer:
- Implement `RoadmapService` for roadmap data aggregation and filtering
- Implement `ReportingService` for roadmap export functionality

## Test Coverage
- Integration tests for the roadmap endpoint, covering:
  - all filters and edge cases
  - health/progress metrics in roadmap responses
  - appliedFilters are present and accurate
  - validation of filters
- Integration tests for roadmap export endpoint for both CSV and PDF formats

## Acceptance Criteria
- Roadmap API returns accurate, filtered, and grouped data.
- All filters (productCode, dateRange, includeCompleted, groupBy) work correctly.
- Filter validations correctly reject malformed requests.
- Additional query parameters in the request are allowed, but ignored without error.
- Health and progress metrics are included in roadmap responses.
- Export functionality works for all supported formats.
- Response times meet performance requirements (<500ms for roadmap search, <2s for export)


FAIL_TO_PASS: RoadmapControllerIntegrationTests